### PR TITLE
feat(frontend): [기능] 테스트 결과 탭 구현

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,7 +6,7 @@ import Dictionary from "./panel/pages/Dictionary";
 import Goal from "./panel/pages/Goal";
 import Ide from "./panel/pages/Ide";
 import Statistics from "./panel/pages/Statistics";
-import Login from "./panel/pages/KakaoLogin"; // 로그인 페이지 컴포넌트
+import Login from "./panel/pages/KakaoLogin";
 
 export default function App() {
     const [isLoggedIn, setIsLoggedIn] = useState(false);

--- a/frontend/src/panel/components/sampleInputOutput/InputOutputTabs.tsx
+++ b/frontend/src/panel/components/sampleInputOutput/InputOutputTabs.tsx
@@ -37,7 +37,6 @@ export default function InputOutputTabs() {
         };
         window.addEventListener("message", onMsg);
 
-        // 초기 데이터 요청
         window.postMessage({ type: "REQUEST_SAMPLES" }, location.origin);
 
         return () => {
@@ -54,7 +53,6 @@ export default function InputOutputTabs() {
                 </div>
             ) : (
                 <>
-                    {/* 탭 헤더 */}
                     <div className="tabs tabs-boxed w-full shrink-0 overflow-x-auto rounded-b-none">
                         {samples.map((s, idx) => (
                             <button
@@ -72,7 +70,6 @@ export default function InputOutputTabs() {
                         ))}
                     </div>
 
-                    {/* 탭 콘텐츠 */}
                     <div className="flex-1 min-h-0 w-full border border-base-300 rounded-t-none rounded-b-box">
                         {samples.map((s, idx) => (
                             <div
@@ -88,7 +85,8 @@ export default function InputOutputTabs() {
                                         </span>
                                     </label>
                                     <pre
-                                        className="grow min-h-0 overflow-auto m-0 whitespace-pre-wrap break-words
+                                        className="grow min-h-0 m-0
+                                            whitespace-pre overflow-x-auto overflow-y-auto
                                             border border-base-300 rounded-box p-3 pb-6
                                             leading-6 font-mono box-border"
                                     >
@@ -104,7 +102,8 @@ export default function InputOutputTabs() {
                                         </span>
                                     </label>
                                     <pre
-                                        className="grow min-h-0 overflow-auto m-0 whitespace-pre-wrap break-words
+                                        className="grow min-h-0 m-0
+                                            whitespace-pre overflow-x-auto overflow-y-auto
                                             border border-base-300 rounded-box p-3 pb-6
                                             leading-6 font-mono box-border"
                                     >

--- a/frontend/src/panel/components/sampleInputOutput/TestResultTabs.tsx
+++ b/frontend/src/panel/components/sampleInputOutput/TestResultTabs.tsx
@@ -1,7 +1,139 @@
-export default function testResultTabs() {
-  return (
-    <>
-      <h1>testResultTabs Component</h1>
-    </>
-  );
+import { useEffect, useState } from "react";
+
+type Sample = { id: number; input: string; output: string };
+
+type SamplePayload = {
+    problemId?: string;
+    problemTitle?: string;
+    url: string;
+    samples: { index: number; input: string; output: string }[];
+    parsedAt: number;
+};
+
+// IDE 실행 결과를 샘플 id 기준으로 저장하기 위한 타입
+type RunResultMap = Record<number, string>;
+
+export default function TestResultTabs() {
+    const [samples, setSamples] = useState<Sample[]>([]);
+    const [results] = useState<RunResultMap>({}); // 나중에 setResults 추가해서 실제 실행 결과 넣으면 됨
+
+    useEffect(() => {
+        const applyPayload = (p?: SamplePayload) => {
+            if (!p) return;
+            const mapped = (p.samples ?? []).map((s) => ({
+                id: s.index,
+                input: s.input,
+                output: s.output,
+            }));
+            setSamples(mapped);
+        };
+
+        const onDoc = (e: Event) =>
+            applyPayload((e as CustomEvent<SamplePayload>).detail);
+        document.addEventListener("boj:samples", onDoc as EventListener);
+
+        const onMsg = (ev: MessageEvent) => {
+            if (ev.origin !== location.origin) return;
+
+            if (ev.data?.type === "BOJ_SAMPLES") {
+                applyPayload(ev.data.payload);
+            }
+
+            // 나중에 IDE 실행 결과 받을 때 이런 식으로 확장하면 됨
+            // if (ev.data?.type === "BOJ_RUN_RESULT") {
+            //     const { sampleId, output } = ev.data.payload;
+            //     setResults(prev => ({ ...prev, [sampleId]: output }));
+            // }
+        };
+        window.addEventListener("message", onMsg);
+
+        // 초기 데이터 요청 (예제 정보)
+        window.postMessage({ type: "REQUEST_SAMPLES" }, location.origin);
+
+        return () => {
+            document.removeEventListener("boj:samples", onDoc as EventListener);
+            window.removeEventListener("message", onMsg);
+        };
+    }, []);
+
+    // 🔍 판정 함수
+    const getJudge = (sample: Sample) => {
+        const userOutput = results[sample.id];
+        if (userOutput == null || userOutput.trim() === "") return "결과 없음";
+
+        const expected = sample.output?.trim();
+        const actual = userOutput?.trim();
+
+        return expected === actual ? "맞았습니다" : "틀렸습니다";
+    };
+
+    // 🔍 판정 텍스트 스타일
+    const judgeStyle = (judge: string) => {
+        if (judge === "맞았습니다") return "text-green-600 font-bold";
+        if (judge === "틀렸습니다") return "text-red-600 font-bold";
+        return "text-gray-500 font-semibold";
+    };
+
+    return (
+        <div className="w-full h-full flex flex-col min-h-0">
+            {samples.length === 0 ? (
+                <div className="alert alert-info">
+                    <span>예제가 아직 감지되지 않았어!</span>
+                </div>
+            ) : (
+                <div className="flex-1 min-h-0 w-full border border-base-300 rounded-box overflow-y-auto p-4 space-y-6">
+                    {samples.map((s) => {
+                        const judge = getJudge(s);
+
+                        return (
+                            <div
+                                key={s.id}
+                                className="grid grid-cols-1 md:grid-cols-2 gap-4"
+                            >
+                                {/* 왼쪽: 예제 출력 */}
+                                <div className="flex flex-col min-h-0">
+                                    <label className="label shrink-0 flex items-center justify-between">
+                                        <span className="label-text font-bold">
+                                            예제 {s.id}
+                                        </span>
+                                    </label>
+
+                                    <pre
+                                        className="grow min-h-0 m-0
+                                            whitespace-pre overflow-x-auto overflow-y-auto
+                                            border border-base-300 rounded-box p-3 pb-6
+                                            leading-6 font-mono box-border"
+                                    >
+                                        {s.output || "(비어있음)"}
+                                    </pre>
+                                </div>
+
+                                {/* 오른쪽: IDE 실행 결과 + 판정 */}
+                                <div className="flex flex-col min-h-0">
+                                    <label className="label shrink-0 flex items-center justify-between">
+                                        <span className="label-text font-bold">
+                                            IDE 실행 결과 {s.id}
+                                        </span>
+                                        <span className={judgeStyle(judge)}>
+                                            {judge}
+                                        </span>
+                                    </label>
+
+                                    <pre
+                                        className="grow min-h-0 m-0
+                                            whitespace-pre overflow-x-auto overflow-y-auto
+                                            border border-base-300 rounded-box p-3 pb-6
+                                            leading-6 font-mono box-border"
+                                    >
+                                        {results[s.id] ??
+                                            "아직 실행 결과가 없어.\n코드를 실행하면 여기로 들어오게 연결하면 돼 😊"}
+                                    </pre>
+                                </div>
+                            </div>
+                        );
+                    })}
+                </div>
+            )}
+        </div>
+    );
 }

--- a/frontend/src/panel/pages/KakaoLogin.tsx
+++ b/frontend/src/panel/pages/KakaoLogin.tsx
@@ -18,6 +18,17 @@ export default function KakaoLogin() {
                     className="w-[320px] md:w-[350px] h-auto"
                 />
             </button>
+
+            <button // 임시 로그인 버튼 (개발용)
+                className="pt-5 bg-transparent border-none hover:scale-105 transition-transform duration-200"
+                onClick={() => {
+                    localStorage.setItem("authToken", "dummy");
+                    location.reload();
+                }}
+            >
+                임시 로그인
+            </button>
+
         </div>
     );
 }


### PR DESCRIPTION
## 개요
- 테스트 결과 탭 구현

## 변경 범위
- [x] Frontend
- [ ] Backend
- [ ] Infra/Docs

## 관련 이슈
- Closes #4 

## 변경 내용
- 테스트용 임시 로그인 버튼
- 테스트 결과 탭 구현
- 비교해서 "맞았습니다" / "틀렸습니다" 출력
- 예제입출력 탭, 테스트 결과 탭에 가로 스크롤 추가

## 체크리스트
- [x] 로컬 빌드/테스트 통과 (frontend / backend)
- [ ] 브레이킹 체인지 시 문서 업데이트
- [x] 라벨/프로젝트/마일스톤 지정

## 스크린샷/로그 (선택)
