### PR TITLE
feat(Backend): 백엔드에 /api/run API 구현 (Piston 연동) #27

### DIFF
--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/controller/CodeRunController.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/controller/CodeRunController.java
@@ -1,0 +1,38 @@
+package com.errorterry.algotrack_backend_spring.controller;
+
+import com.errorterry.algotrack_backend_spring.dto.ErrorResponse;
+import com.errorterry.algotrack_backend_spring.dto.RunRequest;
+import com.errorterry.algotrack_backend_spring.piston.PistonClient;
+import com.errorterry.algotrack_backend_spring.piston.PistonExecuteResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api")
+public class CodeRunController {
+
+    private final PistonClient pistonClient;
+
+    public CodeRunController(PistonClient pistonClient) {
+        this.pistonClient = pistonClient;
+    }
+
+    @PostMapping("/run")
+    public ResponseEntity<?> runCode(@RequestBody RunRequest request) {
+        try {
+            String stdin = request.getStdin() == null ? "" : request.getStdin();
+
+            PistonExecuteResponse result =
+                    pistonClient.execute(request.getLanguage(), request.getCode(), stdin);
+
+            return ResponseEntity.ok(result);
+
+        } catch (Exception e) {
+            ErrorResponse error = new ErrorResponse(
+                    "PISTON_ERROR",
+                    "코드 실행 중 오류가 발생했습니다: " + e.getMessage()
+            );
+            return ResponseEntity.internalServerError().body(error);
+        }
+    }
+}

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/dto/ErrorResponse.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/dto/ErrorResponse.java
@@ -1,0 +1,15 @@
+package com.errorterry.algotrack_backend_spring.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ErrorResponse {
+    private String code;
+    private String message;
+}

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/dto/RunRequest.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/dto/RunRequest.java
@@ -1,0 +1,12 @@
+package com.errorterry.algotrack_backend_spring.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class RunRequest {
+    private String language;
+    private String code;
+    private String stdin;
+}

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/piston/PistonClient.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/piston/PistonClient.java
@@ -1,0 +1,41 @@
+package com.errorterry.algotrack_backend_spring.piston;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+
+@Component
+public class PistonClient {
+
+    private final RestClient restClient;
+
+    public PistonClient(
+            @Value("${piston.base-url:http://localhost:2000/api/v2}") String baseUrl
+    ) {
+        this.restClient = RestClient.builder()
+                .baseUrl(baseUrl)
+                .build();
+    }
+
+    public PistonExecuteResponse execute(String language, String code, String stdin) {
+        String version = "3.10.0"; // 일단 파이썬 버전 고정
+
+        PistonExecuteRequest requestBody = new PistonExecuteRequest();
+        requestBody.setLanguage(language);
+        requestBody.setVersion(version);
+        requestBody.setStdin(stdin);
+        requestBody.setFiles(
+                List.of(new PistonExecuteRequest.FilePart("main.py", code))
+        );
+
+        return restClient.post()
+                .uri("/execute")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(requestBody)
+                .retrieve()
+                .body(PistonExecuteResponse.class);
+    }
+}

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/piston/PistonExecuteRequest.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/piston/PistonExecuteRequest.java
@@ -1,0 +1,30 @@
+package com.errorterry.algotrack_backend_spring.piston;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class PistonExecuteRequest {
+
+    private String language;
+    private String version;
+    private List<FilePart> files;
+    private String stdin;
+
+    @Getter
+    @Setter
+    public static class FilePart {
+        private String name;
+        private String content;
+
+        public FilePart() {}
+
+        public FilePart(String name, String content) {
+            this.name = name;
+            this.content = content;
+        }
+    }
+}

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/piston/PistonExecuteResponse.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/piston/PistonExecuteResponse.java
@@ -1,0 +1,21 @@
+package com.errorterry.algotrack_backend_spring.piston;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PistonExecuteResponse {
+    private RunResult run;
+    private String language;
+    private String version;
+
+    @Getter
+    @Setter
+    public static class RunResult {
+        private String stdout;
+        private String stderr;
+        private Integer code;
+        private String output;
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -28,3 +28,7 @@ spring.jpa.properties.hibernate.format_sql=true
 
 # \uC694\uCCAD \uC885\uB8CC \uC2DC DB \uC138\uC158 \uB2EB\uAE30
 spring.jpa.open-in-view=false
+
+# piston api
+piston:
+base-url: http://localhost:2000/api/v2


### PR DESCRIPTION
## 개요
백엔드에 /api/run API 구현 (Piston 연동)

## 변경 범위
- [ ] Frontend
- [x] Backend
- [ ] Infra/Docs

## 관련 이슈
- Closes #27 

## 변경 내용
- /api/run POST 엔드포인트 생성
- 요청 형식: { language, code, stdin }
- 백엔드에서 Piston 서버로 HTTP 요청 보내기
- Piston 응답 그대로 JSON으로 return
- 에러 발생 시 에러 메시지 구조 통일

## 체크리스트
- [x] 로컬 빌드/테스트 통과 (frontend / backend)
- [ ] 브레이킹 체인지 시 문서 업데이트
- [x] 라벨/프로젝트/마일스톤 지정

## 스크린샷/로그 (선택)
