### PR TITLE
feat(frontend): 예제 출력과 Piston 실행 결과 비교 로직 구현 #29

### DIFF
--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/controller/CodeRunController.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/controller/CodeRunController.java
@@ -21,22 +21,11 @@ public class CodeRunController {
     }
 
     @PostMapping("/run")
-    public ResponseEntity<?> runCode(@RequestBody RunRequest request) {
-        try {
-            String stdin = request.getStdin() == null ? "" : request.getStdin();
-
-            PistonExecuteResponse result =
-                    pistonClient.execute(request.getLanguage(), request.getCode(), stdin);
-
-            return ResponseEntity.ok(result);
-
-        } catch (Exception e) {
-            log.error("runCode error", e);
-            ErrorResponse error = new ErrorResponse(
-                    "PISTON_ERROR",
-                    "코드 실행 중 오류가 발생했습니다: " + e.getMessage()
-            );
-            return ResponseEntity.internalServerError().body(error);
-        }
+    public PistonExecuteResponse runCode(@RequestBody RunRequest request) {
+        return pistonClient.execute(
+                request.getLanguage(),
+                request.getCode(),
+                request.getStdin()
+        );
     }
 }

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/piston/PistonClient.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/piston/PistonClient.java
@@ -1,5 +1,7 @@
 package com.errorterry.algotrack_backend_spring.piston;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
@@ -7,7 +9,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClient;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -16,51 +17,56 @@ import java.util.Map;
 public class PistonClient {
 
     private final RestClient restClient;
+    private final ObjectMapper objectMapper;
 
-    // base-url 은 호스트까지만 (포트만)
     public PistonClient(
-            @Value("${piston.base-url:http://localhost:2000}") String baseUrl
+            @Value("${piston.base-url:https://emkc.org/api/v2/piston}") String baseUrl,
+            ObjectMapper objectMapper
     ) {
         this.restClient = RestClient.builder()
-                .baseUrl(baseUrl)
+                .baseUrl(baseUrl)   // 결과적으로 https://emkc.org/api/v2/piston 이 들어감
                 .build();
+        this.objectMapper = objectMapper;
+
+        log.info("🔧 Piston baseUrl = {}", baseUrl);
     }
 
     public PistonExecuteResponse execute(String language, String code, String stdin) {
+        String version = "3.10.0";
 
-        // 🔹 Piston이 요구하는 JSON 구조 그대로 만들기
-        // {
-        //   "language": "python",
-        //   "version": "3.10.0",
-        //   "files": [ { "content": "print('hello')" } ],
-        //   "stdin": "..."
-        // }
-        Map<String, Object> body = new HashMap<>();
-        body.put("language", language);       // "python"
-        body.put("version", "3.10.0");        // runtimes에서 본 그대로
+        // emkc 문서 스펙에 맞게 JSON 구성
+        Map<String, Object> body = Map.of(
+                "language", language,
+                "version", version,
+                "files", List.of(
+                        Map.of(
+                                "name", "main.py",
+                                "content", code
+                        )
+                ),
+                "stdin", stdin == null ? "" : stdin
+        );
 
-        Map<String, Object> file = new HashMap<>();
-        file.put("content", code);            // name 은 필수 아님, 일단 빼자
-        body.put("files", List.of(file));
-
-        if (stdin != null && !stdin.isBlank()) {
-            body.put("stdin", stdin);
+        // 요청 JSON 로그로 확인
+        try {
+            String json = objectMapper.writeValueAsString(body);
+            log.info("🚀 Piston request JSON = {}", json);
+        } catch (JsonProcessingException e) {
+            log.warn("Failed to serialize piston body", e);
         }
 
         try {
-            log.info("Calling Piston /api/v2/execute with body: {}", body);
-
+            // baseUrl(…/piston) + "/execute"  => https://emkc.org/api/v2/piston/execute
             return restClient.post()
-                    .uri("/api/v2/execute")
+                    .uri("/execute")
                     .contentType(MediaType.APPLICATION_JSON)
                     .body(body)
                     .retrieve()
                     .body(PistonExecuteResponse.class);
-
         } catch (HttpClientErrorException e) {
-            // 400 같은 거 나면, Piston이 돌려준 에러 바디를 로그로 남겨보자
-            log.error("Piston 4xx error status={} body={}",
-                    e.getStatusCode(), e.getResponseBodyAsString());
+            // 여기서 emkc가 주는 에러 내용 그대로 확인 가능
+            log.error("🔥 Piston 4xx status={} headers={} body={}",
+                    e.getStatusCode(), e.getResponseHeaders(), e.getResponseBodyAsString());
             throw e;
         }
     }

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/piston/PistonExecuteRequest.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/piston/PistonExecuteRequest.java
@@ -1,30 +1,26 @@
 package com.errorterry.algotrack_backend_spring.piston;
 
-import lombok.Getter;
-import lombok.Setter;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
-@Getter
-@Setter
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class PistonExecuteRequest {
 
     private String language;
     private String version;
-    private List<FilePart> files;
+    private List<File> files;
     private String stdin;
 
-    @Getter
-    @Setter
-    public static class FilePart {
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class File {
         private String name;
         private String content;
-
-        public FilePart() {}
-
-        public FilePart(String name, String content) {
-            this.name = name;
-            this.content = content;
-        }
     }
 }

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/piston/PistonExecuteResponse.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/piston/PistonExecuteResponse.java
@@ -1,21 +1,26 @@
 package com.errorterry.algotrack_backend_spring.piston;
 
-import lombok.Getter;
-import lombok.Setter;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
 
-@Getter
-@Setter
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class PistonExecuteResponse {
-    private RunResult run;
+
     private String language;
     private String version;
+    private Run run;
 
-    @Getter
-    @Setter
-    public static class RunResult {
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Run {
         private String stdout;
         private String stderr;
-        private Integer code;
         private String output;
+        private Integer code;
+        private String signal;
     }
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -30,5 +30,6 @@ spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.open-in-view=false
 
 # piston api
-piston:
-base-url: http://localhost:2000/api/v2
+piston:base-url: https://emkc.org/api/v2/piston
+
+

--- a/frontend/src/panel/components/sampleInputOutput/InputOutputTabs.tsx
+++ b/frontend/src/panel/components/sampleInputOutput/InputOutputTabs.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 
 type Sample = { id: number; input: string; output: string };
+
 type SamplePayload = {
     problemId?: string;
     problemTitle?: string;
@@ -9,21 +10,22 @@ type SamplePayload = {
     parsedAt: number;
 };
 
-export default function InputOutputTabs() {
+type RunResultMap = Record<number, string>;
+
+export default function TestResultTabs() {
     const [samples, setSamples] = useState<Sample[]>([]);
-    const [active, setActive] = useState<number>(0);
+    const [results, setResults] = useState<RunResultMap>({});
 
     useEffect(() => {
         const applyPayload = (p?: SamplePayload) => {
             if (!p) return;
-            setSamples(
-                (p.samples ?? []).map((s) => ({
-                    id: s.index,
-                    input: s.input,
-                    output: s.output,
-                }))
-            );
-            setActive(0);
+            const mapped = (p.samples ?? []).map((s) => ({
+                id: s.index, // index를 그대로 id로 사용
+                input: s.input,
+                output: s.output,
+            }));
+            console.log("📥 BOJ_SAMPLES 수신:", mapped);
+            setSamples(mapped);
         };
 
         const onDoc = (e: Event) =>
@@ -31,19 +33,84 @@ export default function InputOutputTabs() {
         document.addEventListener("boj:samples", onDoc as EventListener);
 
         const onMsg = (ev: MessageEvent) => {
-            if (ev.origin !== location.origin) return;
-            if (ev.data?.type !== "BOJ_SAMPLES") return;
-            applyPayload(ev.data.payload);
+            console.log("📨 window message:", ev.data);
+
+            if (ev.origin !== window.location.origin) return;
+
+            if (ev.data?.type === "BOJ_SAMPLES") {
+                applyPayload(ev.data.payload);
+            }
+
+            // IDE 실행 결과 수신
+            if (ev.data?.type === "BOJ_RUN_RESULT") {
+                const { sampleId, output } = ev.data.payload ?? {};
+                console.log("✅ BOJ_RUN_RESULT 수신:", sampleId, output);
+
+                // sampleId가 "1" 같이 문자열일 수도 있으니 보정
+                let id: number | null = null;
+                if (typeof sampleId === "number") {
+                    id = sampleId;
+                } else if (
+                    typeof sampleId === "string" &&
+                    !Number.isNaN(Number(sampleId))
+                ) {
+                    id = Number(sampleId);
+                }
+
+                if (id !== null) {
+                    setResults((prev) => ({
+                        ...prev,
+                        [id!]: output ?? "",
+                    }));
+                } else {
+                    console.warn("⚠️ 잘못된 sampleId:", sampleId);
+                }
+            }
         };
         window.addEventListener("message", onMsg);
 
-        window.postMessage({ type: "REQUEST_SAMPLES" }, location.origin);
+        // 예제 정보 요청
+        window.postMessage({ type: "REQUEST_SAMPLES" }, window.location.origin);
 
         return () => {
             document.removeEventListener("boj:samples", onDoc as EventListener);
             window.removeEventListener("message", onMsg);
         };
     }, []);
+
+    // 공백/개행 보정
+    const normalize = (s: string) => {
+        return s
+            .replace(/\r\n/g, "\n")
+            .split("\n")
+            .map((line) => line.replace(/\s+$/g, "")) // 각 줄 끝 공백 제거
+            .join("\n")
+            .trimEnd();
+    };
+
+    const getJudge = (sample: Sample) => {
+        const userOutput = results[sample.id];
+
+        console.log("🔍 judge check:", {
+            sampleId: sample.id,
+            expected: sample.output,
+            actual: userOutput,
+            resultsMap: results,
+        });
+
+        if (userOutput == null || userOutput.trim() === "") return "결과 없음";
+
+        const expected = normalize(sample.output ?? "");
+        const actual = normalize(userOutput ?? "");
+
+        return expected === actual ? "맞았습니다" : "틀렸습니다";
+    };
+
+    const judgeStyle = (judge: string) => {
+        if (judge === "맞았습니다") return "text-green-600 font-bold";
+        if (judge === "틀렸습니다") return "text-red-600 font-bold";
+        return "text-gray-500 font-semibold";
+    };
 
     return (
         <div className="w-full h-full flex flex-col min-h-0">
@@ -52,68 +119,48 @@ export default function InputOutputTabs() {
                     <span>예제가 아직 감지되지 않았어!</span>
                 </div>
             ) : (
-                <>
-                    <div className="tabs tabs-boxed w-full shrink-0 overflow-x-auto rounded-b-none">
-                        {samples.map((s, idx) => (
-                            <button
-                                key={s.id}
-                                onClick={() => setActive(idx)}
-                                className={`tab px-6 text-sm md:text-base transition-colors duration-150 font-semibold
-                                    ${
-                                    active === idx
-                                        ? "tab-active bg-neutral-content text-white shadow-md"
-                                        : "hover:bg-neutral-content hover:text-white"
-                                }`}
-                            >
-                                예제 {s.id}
-                            </button>
-                        ))}
-                    </div>
+                <div className="flex-1 min-h-0 w-full border border-base-300 rounded-box overflow-y-auto p-4 space-y-6">
+                    {samples.map((s) => {
+                        const judge = getJudge(s);
 
-                    <div className="flex-1 min-h-0 w-full border border-base-300 rounded-t-none rounded-b-box">
-                        {samples.map((s, idx) => (
+                        return (
                             <div
                                 key={s.id}
-                                hidden={active !== idx}
-                                className="h-full min-h-0 grid grid-cols-1 md:grid-cols-2 gap-4 p-4"
+                                className="grid grid-cols-1 md:grid-cols-2 gap-4"
                             >
-                                {/* 입력 */}
+                                {/* 왼쪽: 예제 출력 */}
                                 <div className="flex flex-col min-h-0">
-                                    <label className="label shrink-0">
-                                        <span className="label-text font-semibold">
-                                            예제 입력 {s.id}
+                                    <label className="label shrink-0 flex items-center justify-between">
+                                        <span className="label-text font-bold">
+                                            예제 {s.id}
                                         </span>
                                     </label>
-                                    <pre
-                                        className="grow min-h-0 m-0
-                                            whitespace-pre overflow-x-auto overflow-y-auto
-                                            border border-base-300 rounded-box p-3 pb-6
-                                            leading-6 font-mono box-border"
-                                    >
-                                        {s.input || "(비어있음)"}
-                                    </pre>
-                                </div>
 
-                                {/* 출력 */}
-                                <div className="flex flex-col min-h-0">
-                                    <label className="label shrink-0">
-                                        <span className="label-text font-semibold">
-                                            예제 출력 {s.id}
-                                        </span>
-                                    </label>
-                                    <pre
-                                        className="grow min-h-0 m-0
-                                            whitespace-pre overflow-x-auto overflow-y-auto
-                                            border border-base-300 rounded-box p-3 pb-6
-                                            leading-6 font-mono box-border"
-                                    >
+                                    <pre className="grow min-h-0 m-0 whitespace-pre overflow-x-auto overflow-y-auto border border-base-300 rounded-box p-3 pb-6 leading-6 font-mono box-border">
                                         {s.output || "(비어있음)"}
                                     </pre>
                                 </div>
+
+                                {/* 오른쪽: IDE 실행 결과 + 판정 */}
+                                <div className="flex flex-col min-h-0">
+                                    <label className="label shrink-0 flex items-center justify-between">
+                                        <span className="label-text font-bold">
+                                            IDE 실행 결과 {s.id}
+                                        </span>
+                                        <span className={judgeStyle(judge)}>
+                                            {judge}
+                                        </span>
+                                    </label>
+
+                                    <pre className="grow min-h-0 m-0 whitespace-pre overflow-x-auto overflow-y-auto border border-base-300 rounded-box p-3 pb-6 leading-6 font-mono box-border">
+                                        {results[s.id] ??
+                                            '아직 실행 결과가 없어.\n코드를 실행하면 여기로 들어오게 연결돼 😊'}
+                                    </pre>
+                                </div>
                             </div>
-                        ))}
-                    </div>
-                </>
+                        );
+                    })}
+                </div>
             )}
         </div>
     );

--- a/frontend/src/panel/pages/Ide.tsx
+++ b/frontend/src/panel/pages/Ide.tsx
@@ -1,54 +1,62 @@
-// src/pages/Ide.tsx
 import { useRef, useState } from "react";
 import IdeUI from "../components/ide/IdeUI";
 import type { IdeUIHandle } from "../components/ide/IdeUI";
 import IdeHeader from "../components/ide/IdeHeader";
 import IdePageTabs from "../components/sampleInputOutput/IdePageTabs";
-import api from "../../shared/api"; // 너가 쓰는 경로에 맞춰서!
-
-type RunResult = any; // 필요하면 나중에 Piston 응답 타입 정의해도 됨
+import api from "../../shared/api";
 
 export default function Ide() {
     const editorRef = useRef<IdeUIHandle | null>(null);
 
-    const [language, setLanguage] = useState<string>("python");
-    const [stdin, setStdin] = useState<string>("");
-    const [output, setOutput] = useState<string>("");
-    const [error, setError] = useState<string>("");
-    const [loading, setLoading] = useState<boolean>(false);
+    const [language, setLanguage] = useState<string>("");
+    const [loading, setLoading] = useState(false);
 
     const handleRun = async () => {
         const code = editorRef.current?.getCode() ?? "";
 
-        setError("");
-        setOutput("");
-
         if (!language) {
-            setError("언어를 선택해 주세요.");
+            alert("언어를 선택해 주세요.");
             return;
         }
         if (!code.trim()) {
-            setError("실행할 코드가 비어 있어요.");
+            alert("실행할 코드가 비어 있어요.");
             return;
         }
 
         try {
             setLoading(true);
 
-            const body = {
-                language,       // ex) "python"
-                code,           // 에디터 내용
-                stdin,          // 아래 textarea에 입력한 값
-            };
-
+            // 👉 지금은 stdin 자동 주입 안 하니까 일단 빈 문자열
+            const body = { language, code, stdin: "" };
             const res = await api.post("/api/run", body);
 
-            // Piston 응답 구조를 아직 정확히 안 쓴 상태라 우선 전체를 JSON으로 보여주자
-            setOutput(JSON.stringify(res.data, null, 2));
+            console.log("✅ /api/run result:", res.data);
 
+            // 👉 Piston 응답에서 stdout 뽑기
+            const stdout =
+                (res.data as any)?.run?.stdout ??
+                (res.data as any)?.stdout ??
+                "";
+
+            console.log("✅ extracted stdout:", JSON.stringify(stdout));
+
+            // 👉 실행 결과를 아래 테스트 탭으로 전달
+            //    일단 예제 1번 기준으로 sampleId = 1 고정
+            window.postMessage(
+                {
+                    type: "BOJ_RUN_RESULT",
+                    payload: {
+                        sampleId: 1,      // 🔥 TestResultTabs 에서도 id가 1인 예제가 있어야 함
+                        output: stdout ?? "",
+                    },
+                },
+                window.location.origin,
+            );
         } catch (e: any) {
             console.error(e);
-            setError(e.response?.data?.message ?? e.message ?? "실행 중 오류가 발생했어요.");
+            alert(
+                "실행 중 오류가 발생했어요. (자세한 내용은 콘솔 로그 확인)"
+            );
         } finally {
             setLoading(false);
         }
@@ -59,11 +67,8 @@ export default function Ide() {
             {/* 위쪽 IDE 영역 */}
             <div
                 className="rounded-lg border border-base-300 grid overflow-hidden"
-                style={{
-                    gridTemplateRows: "12% 88%",
-                }}
+                style={{ gridTemplateRows: "12% 88%" }}
             >
-                {/* 헤더 */}
                 <div className="relative z-50 w-full min-w-0 flex flex-wrap items-center justify-end gap-2 sm:gap-3 px-4 py-2 border-b border-base-300 bg-base-200">
                     <IdeHeader
                         language={language}
@@ -73,57 +78,12 @@ export default function Ide() {
                     />
                 </div>
 
-                {/* 에디터 + stdin + 결과 */}
                 <div className="min-h-0 rounded-b-lg overflow-hidden">
-                    <div className="flex flex-col h-full">
-                        {/* 에디터 */}
-                        <div className="flex-1 min-h-0">
-                            <IdeUI ref={editorRef} />
-                        </div>
-
-                        {/* stdin & 결과 패널 */}
-                        <div className="border-t border-base-300 grid grid-cols-1 md:grid-cols-2 gap-2 p-3 bg-base-200/50">
-                            {/* stdin 입력 */}
-                            <div className="flex flex-col gap-1">
-                                <span className="text-sm font-semibold">표준 입력 (stdin)</span>
-                                <textarea
-                                    className="textarea textarea-bordered textarea-sm md:textarea-md w-full resize-none"
-                                    rows={4}
-                                    placeholder="예제 입력이나 테스트 입력을 여기에 적어봐 👉"
-                                    value={stdin}
-                                    onChange={(e) => setStdin(e.target.value)}
-                                />
-                            </div>
-
-                            {/* 결과 출력 */}
-                            <div className="flex flex-col gap-1">
-                                <span className="text-sm font-semibold">실행 결과</span>
-                                <div className="border border-base-300 rounded-lg bg-base-100 h-full p-2 overflow-auto text-xs md:text-sm whitespace-pre-wrap">
-                                    {loading && (
-                                        <div className="flex items-center gap-2 text-sm">
-                                            <span className="loading loading-spinner loading-sm" />
-                                            <span>코드 실행 중...</span>
-                                        </div>
-                                    )}
-                                    {!loading && error && (
-                                        <div className="text-error">{error}</div>
-                                    )}
-                                    {!loading && !error && output && (
-                                        <pre>{output}</pre>
-                                    )}
-                                    {!loading && !error && !output && (
-                                        <span className="text-base-content/60 text-sm">
-                      아직 실행 결과가 없어요. 코드를 작성하고 Run 버튼을 눌러봐! 🚀
-                    </span>
-                                    )}
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                    <IdeUI ref={editorRef} />
                 </div>
             </div>
 
-            {/* 아래쪽 예제 입출력 영역 (지금 건들지 말기) */}
+            {/* 아래쪽 예제 입출력 / 테스트 결과 영역 */}
             <div className="rounded-lg border border-base-300 h-full flex flex-col overflow-hidden">
                 <div className="flex-1 min-h-0">
                     <IdePageTabs />


### PR DESCRIPTION
## 개요
- 예제 출력과 Piston 실행 결과 비교 로직 구현

## 변경 범위
- [x] Frontend
- [ ] Backend
- [ ] Infra/Docs

## 관련 이슈
- Closes #29 

## 변경 내용
- 실행 결과와 예제 output 문자열 비교
- 정답 / 오답 UI 표현
- 공백/개행 차이로 오답되는 문제 보정

## 체크리스트
- [x] 로컬 빌드/테스트 통과 (frontend / backend)
- [ ] 브레이킹 체인지 시 문서 업데이트
- [x] 라벨/프로젝트/마일스톤 지정

## 스크린샷/로그 (선택)
