### PR TITLE
feat(backend): [Backend] Algorithm / AlgorithmDictionary JPA 구현

### DIFF
--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/controller/AlgorithmController.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/controller/AlgorithmController.java
@@ -1,0 +1,30 @@
+package com.errorterry.algotrack_backend_spring.controller;
+
+import com.errorterry.algotrack_backend_spring.dto.AlgorithmResponseDto;
+import com.errorterry.algotrack_backend_spring.service.AlgorithmService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/algorithm")
+@RequiredArgsConstructor
+public class AlgorithmController {
+
+    private final AlgorithmService algorithmService;
+
+    // 전체 조회
+    @GetMapping
+    public ResponseEntity<List<AlgorithmResponseDto>> getAllAlgorithm() {
+        return ResponseEntity.ok(algorithmService.getAllAlgorithm());
+    }
+
+    // definition NOT NULL 조회
+    @GetMapping("/with-definition")
+    public ResponseEntity<List<AlgorithmResponseDto>> getAlgorithmsWithDefinition() {
+        return ResponseEntity.ok(algorithmService.getAlgorithmWithDefinition());
+    }
+
+}

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/controller/AlgorithmDictionaryController.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/controller/AlgorithmDictionaryController.java
@@ -1,0 +1,32 @@
+package com.errorterry.algotrack_backend_spring.controller;
+
+import com.errorterry.algotrack_backend_spring.dto.AlgorithmDictionaryResponseDto;
+import com.errorterry.algotrack_backend_spring.service.AlgorithmDictionaryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/algorithm--dictionary")
+@RequiredArgsConstructor
+public class AlgorithmDictionaryController {
+
+    private final AlgorithmDictionaryService algorithmDictionaryService;
+
+    // 전체 조회
+    @GetMapping
+    public ResponseEntity<List<AlgorithmDictionaryResponseDto>> getAllAlgorithmDictionary() {
+        return ResponseEntity.ok(algorithmDictionaryService.getAllAlgorithmDictionary());
+    }
+
+    // algorithm_id 기준 조회
+    @GetMapping("/by-algorithm/{algorithmId}")
+    public ResponseEntity<List<AlgorithmDictionaryResponseDto>> getByAlgorithmId(
+            @PathVariable Integer algorithmId
+    ) {
+        return ResponseEntity.ok(algorithmDictionaryService.getByAlgorithmId(algorithmId));
+    }
+
+}

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/domain/Algorithm.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/domain/Algorithm.java
@@ -1,0 +1,33 @@
+package com.errorterry.algotrack_backend_spring.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+
+@Entity
+@Table(
+        name = "algorithm",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uq_algorithm_name",
+                        columnNames = "algorithm_name"
+                )
+        }
+)
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor @Builder
+@DynamicInsert
+public class Algorithm {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "algorithm_id")
+    private Integer algorithmId;
+
+    @Column(name = "algorithm_name", nullable = true, columnDefinition = "text")
+    private String algorithmName;
+
+    @Column(name = "definition", nullable = false, columnDefinition = "text")
+    private String definition;
+
+}

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/domain/AlgorithmDictionary.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/domain/AlgorithmDictionary.java
@@ -1,0 +1,44 @@
+package com.errorterry.algotrack_backend_spring.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+
+@Entity
+@Table(
+        name = "algorithm_dictionary",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uq_algorithm_dictionary",
+                        columnNames = {"algorithm_id", "algorithm_name"}
+                )
+        }
+)
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor @Builder
+@DynamicInsert
+public class AlgorithmDictionary {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "algorithm_dictionary_id")
+    private Integer algorithmDictionaryId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(
+            name = "algorithm_id",
+            nullable = false,
+            foreignKey = @ForeignKey(name = "fk_algorithm_dictionary_algorithm")
+    )
+    private Algorithm algorithm;
+
+    @Column(name = "algorithm_name", nullable = false, columnDefinition = "text")
+    private String algorithmName;
+
+    @Column(name = "definition", nullable = false, columnDefinition = "text")
+    private String definition;
+
+    @Column(name = "example", nullable = false, columnDefinition = "text")
+    private String example;
+
+}

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/dto/AlgorithmDictionaryResponseDto.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/dto/AlgorithmDictionaryResponseDto.java
@@ -1,0 +1,27 @@
+package com.errorterry.algotrack_backend_spring.dto;
+
+import com.errorterry.algotrack_backend_spring.domain.AlgorithmDictionary;
+
+import lombok.*;
+
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor @Builder
+public class AlgorithmDictionaryResponseDto {
+
+    private Integer algorithmDictionaryId;
+    private Integer algorithmId;
+    private String algorithmName;
+    private String definition;
+    private String example;
+
+    public static AlgorithmDictionaryResponseDto from(AlgorithmDictionary algorithmDictionary) {
+        return AlgorithmDictionaryResponseDto.builder()
+                .algorithmDictionaryId(algorithmDictionary.getAlgorithmDictionaryId())
+                .algorithmId(algorithmDictionary.getAlgorithm().getAlgorithmId())
+                .algorithmName(algorithmDictionary.getAlgorithmName())
+                .definition(algorithmDictionary.getDefinition())
+                .example(algorithmDictionary.getExample())
+                .build();
+    }
+
+}

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/dto/AlgorithmResponseDto.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/dto/AlgorithmResponseDto.java
@@ -1,0 +1,23 @@
+package com.errorterry.algotrack_backend_spring.dto;
+
+import com.errorterry.algotrack_backend_spring.domain.Algorithm;
+
+import lombok.*;
+
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor @Builder
+public class AlgorithmResponseDto {
+
+    private Integer algorithmId;
+    private String algorithmName;
+    private String definition;
+
+    public static AlgorithmResponseDto from(Algorithm algorithm) {
+        return AlgorithmResponseDto.builder()
+                .algorithmId(algorithm.getAlgorithmId())
+                .algorithmName(algorithm.getAlgorithmName())
+                .definition(algorithm.getDefinition())
+                .build();
+    }
+
+}

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/repository/AlgorithmDictionaryRepository.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/repository/AlgorithmDictionaryRepository.java
@@ -1,0 +1,13 @@
+package com.errorterry.algotrack_backend_spring.repository;
+
+import com.errorterry.algotrack_backend_spring.domain.AlgorithmDictionary;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AlgorithmDictionaryRepository extends JpaRepository<AlgorithmDictionary, Integer> {
+
+    // algorithm_id 기준 조회
+    List<AlgorithmDictionary> findByAlgorithmAlgorithmId(Integer algorithmId);
+
+}

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/repository/AlgorithmRepository.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/repository/AlgorithmRepository.java
@@ -1,0 +1,13 @@
+package com.errorterry.algotrack_backend_spring.repository;
+
+import com.errorterry.algotrack_backend_spring.domain.Algorithm;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AlgorithmRepository extends JpaRepository<Algorithm, Integer> {
+
+    // definition NOT NULL 조회
+    List<Algorithm> findByDefinitionIsNotNull();
+
+}

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/service/AlgorithmDictionaryService.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/service/AlgorithmDictionaryService.java
@@ -1,0 +1,33 @@
+package com.errorterry.algotrack_backend_spring.service;
+
+import com.errorterry.algotrack_backend_spring.dto.AlgorithmDictionaryResponseDto;
+import com.errorterry.algotrack_backend_spring.repository.AlgorithmDictionaryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class AlgorithmDictionaryService {
+
+    private final AlgorithmDictionaryRepository algorithmDictionaryRepository;
+
+    // 전체 조회
+    public List<AlgorithmDictionaryResponseDto> getAllAlgorithmDictionary() {
+        return algorithmDictionaryRepository.findAll()
+                .stream()
+                .map(AlgorithmDictionaryResponseDto::from)
+                .collect(Collectors.toList());
+    }
+
+    // algorithm_id 기준 조회
+    public List<AlgorithmDictionaryResponseDto> getByAlgorithmId(Integer algorithmId) {
+        return algorithmDictionaryRepository.findByAlgorithmAlgorithmId(algorithmId)
+                .stream()
+                .map(AlgorithmDictionaryResponseDto::from)
+                .collect(Collectors.toList());
+    }
+
+}

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/service/AlgorithmService.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/service/AlgorithmService.java
@@ -1,0 +1,33 @@
+package com.errorterry.algotrack_backend_spring.service;
+
+import com.errorterry.algotrack_backend_spring.dto.AlgorithmResponseDto;
+import com.errorterry.algotrack_backend_spring.repository.AlgorithmRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class AlgorithmService {
+
+    private final AlgorithmRepository algorithmRepository;
+
+    // 전체 조회
+    public List<AlgorithmResponseDto> getAllAlgorithm() {
+        return algorithmRepository.findAll()
+                .stream()
+                .map(AlgorithmResponseDto::from)
+                .collect(Collectors.toList());
+    }
+
+    // definition NOT NULL 조회
+    public List<AlgorithmResponseDto> getAlgorithmWithDefinition() {
+        return algorithmRepository.findByDefinitionIsNotNull()
+                .stream()
+                .map(AlgorithmResponseDto::from)
+                .collect(Collectors.toList());
+    }
+
+}


### PR DESCRIPTION
## 개요
- Algorithm / AlgorithmDictionary JPA 구현

## 변경 범위
- [ ] Frontend
- [x] Backend
- [ ] Infra/Docs

## 관련 이슈
- Closes #33 

## 변경 내용
- Algorithm / AlgorithmDictionary 엔티티 생성
- Algorithm / AlgorithmDictionary Repository 생성
- Algorithm / AlgorithmDictionary Dto 구현
- Algorithm / AlgorithmDictionary Service 구현
- Algorithm / AlgorithmDictionary Controller 구현

## 체크리스트
- [x] 로컬 빌드/테스트 통과 (frontend / backend)
- [ ] 브레이킹 체인지 시 문서 업데이트
- [x] 라벨/프로젝트/마일스톤 지정

## 스크린샷/로그 (선택)
