### PR TITLE
feat(frontend): IDE 페이지 모든 예제 실행결과 구현 #42

### DIFF
--- a/frontend/extension/content/content.js
+++ b/frontend/extension/content/content.js
@@ -10,7 +10,7 @@
     // =========================
     const btn = document.createElement("button");
     btn.id = "bj-helper-toggle-btn";
-    btn.textContent = "Helper 열기";
+    btn.textContent = "Algo-Track";
     document.body.appendChild(btn);
 
     // =========================
@@ -109,12 +109,12 @@
         if (open) {
             panel.classList.add("open");
             document.documentElement.classList.add("bj-helper-open");
-            btn.textContent = "Helper 닫기";
+            btn.textContent = "Algo-Track";
             if (btn.parentElement !== panel) panel.appendChild(btn);
         } else {
             panel.classList.remove("open");
             document.documentElement.classList.remove("bj-helper-open");
-            btn.textContent = "Helper 열기";
+            btn.textContent = "Algo-Track";
             if (btn.parentElement !== document.body) document.body.appendChild(btn);
         }
     };

--- a/frontend/src/panel/components/sampleInputOutput/IdePageTabs.tsx
+++ b/frontend/src/panel/components/sampleInputOutput/IdePageTabs.tsx
@@ -8,7 +8,7 @@ export default function IdePageTabs() {
     return (
         <div className="w-full h-full flex flex-col min-h-0">
             {/* 상단 탭 버튼 */}
-            <div className="flex space-x-5 mb-4 shrink-0">
+            <div className="flex space-x-5 shrink-0">
                 <button
                     className={`btn btn-wide min-h-18 gap-4 text-[18px] md:text-[20px] font-semibold ${
                         activeTab === "io" ? "btn-success" : ""

--- a/frontend/src/panel/pages/Ide.tsx
+++ b/frontend/src/panel/pages/Ide.tsx
@@ -1,62 +1,138 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import IdeUI from "../components/ide/IdeUI";
 import type { IdeUIHandle } from "../components/ide/IdeUI";
 import IdeHeader from "../components/ide/IdeHeader";
 import IdePageTabs from "../components/sampleInputOutput/IdePageTabs";
 import api from "../../shared/api";
+import { safeSetProblemStorage } from "../../shared/safeStorage";
+
+type Sample = { id: number; input: string; output: string };
+type SamplePayload = {
+    problemId?: string;
+    problemTitle?: string;
+    url: string;
+    samples: { index: number; input: string; output: string }[];
+    parsedAt: number;
+};
+
+// 문제 ID 추출
+const getProblemId = () => {
+    const match = window.location.pathname.match(/\/problem\/(\d+)/);
+    return match ? match[1] : "default";
+};
 
 export default function Ide() {
-    const editorRef = useRef<IdeUIHandle | null>(null);
+    const problemId = getProblemId();
 
+    const editorRef = useRef<IdeUIHandle | null>(null);
     const [language, setLanguage] = useState<string>("");
     const [loading, setLoading] = useState(false);
+    const [samples, setSamples] = useState<Sample[]>([]);
 
+    // ⭐ 언어 복원
+    useEffect(() => {
+        const saved = localStorage.getItem(`ide_language_${problemId}`);
+        if (saved) setLanguage(saved);
+    }, [problemId]);
+
+    // ⭐ 언어 저장
+    useEffect(() => {
+        if (language) {
+            safeSetProblemStorage(`ide_language_${problemId}`, language);
+        }
+    }, [language, problemId]);
+
+    // ⭐ 코드 복원
+    useEffect(() => {
+        const saved = localStorage.getItem(`ide_code_${problemId}`);
+        if (saved && editorRef.current) {
+            editorRef.current.setCode(saved);
+        }
+    }, [problemId]);
+
+    // ⭐ 코드 변경 감지 → 저장
+    const handleCodeChange = () => {
+        const code = editorRef.current?.getCode() ?? "";
+        safeSetProblemStorage(`ide_code_${problemId}`, code);
+    };
+
+    // 예제 수신
+    useEffect(() => {
+        const apply = (p?: SamplePayload) => {
+            if (!p) return;
+            setSamples(
+                (p.samples ?? []).map(s => ({
+                    id: s.index,
+                    input: s.input,
+                    output: s.output
+                }))
+            );
+        };
+
+        const onDoc = (e: Event) => apply((e as CustomEvent<SamplePayload>).detail);
+        document.addEventListener("boj:samples", onDoc as EventListener);
+
+        const onMsg = (ev: MessageEvent) => {
+            if (ev.origin !== window.location.origin) return;
+            if (ev.data?.type === "BOJ_SAMPLES") apply(ev.data.payload);
+        };
+
+        window.addEventListener("message", onMsg);
+        window.postMessage({ type: "REQUEST_SAMPLES" }, window.location.origin);
+
+        return () => {
+            document.removeEventListener("boj:samples", onDoc as EventListener);
+            window.removeEventListener("message", onMsg);
+        };
+    }, []);
+
+    // 실행
     const handleRun = async () => {
         const code = editorRef.current?.getCode() ?? "";
 
-        if (!language) {
-            alert("언어를 선택해 주세요.");
-            return;
-        }
-        if (!code.trim()) {
-            alert("실행할 코드가 비어 있어요.");
-            return;
-        }
+        if (!language) return alert("언어를 선택해 주세요.");
+        if (!code.trim()) return alert("실행할 코드가 비어 있어요.");
+
+        setLoading(true);
 
         try {
-            setLoading(true);
+            // 예제 없는 경우
+            if (samples.length === 0) {
+                const res = await api.post("/api/run", {
+                    language,
+                    code,
+                    stdin: ""
+                });
 
-            // 👉 지금은 stdin 자동 주입 안 하니까 일단 빈 문자열
-            const body = { language, code, stdin: "" };
-            const res = await api.post("/api/run", body);
+                const stdout =
+                    res.data?.run?.stdout ?? res.data?.stdout ?? "";
 
-            console.log("✅ /api/run result:", res.data);
-
-            // 👉 Piston 응답에서 stdout 뽑기
-            const stdout =
-                (res.data as any)?.run?.stdout ??
-                (res.data as any)?.stdout ??
-                "";
-
-            console.log("✅ extracted stdout:", JSON.stringify(stdout));
-
-            // 👉 실행 결과를 아래 테스트 탭으로 전달
-            //    일단 예제 1번 기준으로 sampleId = 1 고정
-            window.postMessage(
-                {
+                window.postMessage({
                     type: "BOJ_RUN_RESULT",
-                    payload: {
-                        sampleId: 1,      // 🔥 TestResultTabs 에서도 id가 1인 예제가 있어야 함
-                        output: stdout ?? "",
-                    },
-                },
-                window.location.origin,
-            );
-        } catch (e: any) {
+                    payload: { sampleId: 0, output: stdout }
+                }, window.location.origin);
+                return;
+            }
+
+            // 예제 있는 경우
+            for (const s of samples) {
+                const res = await api.post("/api/run", {
+                    language,
+                    code,
+                    stdin: s.input
+                });
+
+                const stdout =
+                    res.data?.run?.stdout ?? res.data?.stdout ?? "";
+
+                window.postMessage({
+                    type: "BOJ_RUN_RESULT",
+                    payload: { sampleId: s.id, output: stdout }
+                }, window.location.origin);
+            }
+        } catch (e) {
             console.error(e);
-            alert(
-                "실행 중 오류가 발생했어요. (자세한 내용은 콘솔 로그 확인)"
-            );
+            alert("실행 중 오류가 발생했어요! 콘솔 확인해줘.");
         } finally {
             setLoading(false);
         }
@@ -64,12 +140,13 @@ export default function Ide() {
 
     return (
         <div className="h-[calc(100vh-100px)] grid grid-rows-2 gap-4 p-4 overflow-hidden">
-            {/* 위쪽 IDE 영역 */}
+
+            {/* 상단 IDE 영역 */}
             <div
                 className="rounded-lg border border-base-300 grid overflow-hidden"
                 style={{ gridTemplateRows: "12% 88%" }}
             >
-                <div className="relative z-50 w-full min-w-0 flex flex-wrap items-center justify-end gap-2 sm:gap-3 px-4 py-2 border-b border-base-300 bg-base-200">
+                <div className="relative z-50 w-full flex items-center justify-end gap-2 px-4 py-2 border-b bg-base-200">
                     <IdeHeader
                         language={language}
                         onChangeLanguage={setLanguage}
@@ -78,13 +155,13 @@ export default function Ide() {
                     />
                 </div>
 
-                <div className="min-h-0 rounded-b-lg overflow-hidden">
-                    <IdeUI ref={editorRef} />
+                <div className="min-h-0 overflow-hidden">
+                    <IdeUI ref={editorRef} onChange={handleCodeChange} />
                 </div>
             </div>
 
-            {/* 아래쪽 예제 입출력 / 테스트 결과 영역 */}
-            <div className="rounded-lg border border-base-300 h-full flex flex-col overflow-hidden">
+            {/* 아래쪽 예제 탭 */}
+            <div className="rounded-lg flex flex-col overflow-hidden">
                 <div className="flex-1 min-h-0">
                     <IdePageTabs />
                 </div>

--- a/frontend/src/shared/safeStorage.ts
+++ b/frontend/src/shared/safeStorage.ts
@@ -1,0 +1,33 @@
+// 로컬스토리지 자동정리 함수
+
+export function safeSetProblemStorage(key: string, value: string) {
+    try {
+        localStorage.setItem(key, value);
+        return;
+    } catch (e) {
+        console.warn("⚠️ localStorage 용량 부족! 오래된 데이터 제거 중...", e);
+    }
+
+    // 저장 실패 → 오래된 문제 데이터부터 삭제
+    const targets = Object.keys(localStorage)
+        .filter(k =>
+            k.startsWith("ide_code_") ||
+            k.startsWith("ide_results_") ||
+            k.startsWith("ide_language_")
+        )
+        .sort(); // 오름차순: 문제 번호 작은 순 → 오래된 순
+
+    if (targets.length > 0) {
+        const oldest = targets[0];
+        console.log(`🗑️ 오래된 문제 데이터 삭제: ${oldest}`);
+        localStorage.removeItem(oldest);
+    }
+
+    // 삭제 후 재시도
+    try {
+        localStorage.setItem(key, value);
+        console.log("✨ 재저장 성공!");
+    } catch (e) {
+        console.warn("❌ 재저장 실패! localStorage 가득 참", e);
+    }
+}


### PR DESCRIPTION
## 개요
IDE 페이지 모든 예제 실행결과 구현

## 변경 범위
- [x] Frontend
- [ ] Backend
- [ ] Infra/Docs

## 관련 이슈
- Closes #42 

## 변경 내용
- IDE 페이지 모든 예제 실행결과 구현
- 언어선택, ide코드, 실행결과를 문제별 로컬스토리지 저장
- ui 개선 - 각 예제 사이 구분선 추가
- 실행 테스트

## 체크리스트
- [x] 로컬 빌드/테스트 통과 (frontend / backend)
- [ ] 브레이킹 체인지 시 문서 업데이트
- [x] 라벨/프로젝트/마일스톤 지정

## 스크린샷/로그 (선택)
