### PR TITLE
chore(backend): Swagger UI HTTPS 혼합 콘텐츠(HTTP 호출) 오류 해결 #46

### DIFF
--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/config/SwaggerConfig.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/config/SwaggerConfig.java
@@ -1,0 +1,20 @@
+package com.errorterry.algotrack_backend_spring.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                // 현재 도메인(https://algotrack.store)을 기준으로 /api 같은 식으로 날림
+                // 완전 고정하고 싶으면: new Server().url("https://algotrack.store")
+                .servers(List.of(new Server().url("/")));
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -32,4 +32,8 @@ spring.jpa.open-in-view=false
 # piston api
 piston:base-url: https://emkc.org/api/v2/piston
 
+#\uD504\uB85D\uC2DC \uD5E4\uB354 \uC124\uC815
+server.forward-headers-strategy=framework
+
+
 

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -30,7 +30,7 @@ spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.open-in-view=false
 
 # piston api
-piston:base-url: https://emkc.org/api/v2/piston
+piston.base-url=https://emkc.org/api/v2/piston
 
 #\uD504\uB85D\uC2DC \uD5E4\uB354 \uC124\uC815
 server.forward-headers-strategy=framework


### PR DESCRIPTION
## 개요
Swagger UI HTTPS 혼합 콘텐츠(HTTP 호출) 오류 해결

## 변경 범위
- [ ] Frontend
- [x] Backend
- [ ] Infra/Docs

## 관련 이슈
- Closes #46 

## 변경 내용
- Spring Boot 설정 수정
    server.forward-headers-strategy=framework 추가하여
    nginx로부터 전달되는 X-Forwarded-Proto 헤더를 스프링이 인식하도록 설정함
    → 스프링이 HTTPS 환경임을 올바르게 판단하도록 조치

- nginx Reverse Proxy 헤더 설정 추가

    아래 두 줄을 nginx location / 블록에 추가:

    proxy_set_header X-Forwarded-Proto $scheme;
    proxy_set_header X-Forwarded-Host $host;

    → Swagger/OpenAPI가 HTTP 대신 HTTPS를 서버 URL로 설정하도록 만듦
    → 혼합 콘텐츠 문제 해결됨

## 체크리스트
- [x] 로컬 빌드/테스트 통과 (frontend / backend)
- [ ] 브레이킹 체인지 시 문서 업데이트
- [x] 라벨/프로젝트/마일스톤 지정

## 스크린샷/로그 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Swagger/OpenAPI 통합이 추가되어 애플리케이션의 API 문서화가 가능해졌습니다.

* **Chores**
  * 서버 헤더 포워딩 동작이 업데이트되었습니다.
  * 일부 설정 키명이 정리되어 구성 파일의 항목명이 변경되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->