### PR TITLE
chore(backend): JWT 보안 정책 조정: 목표/통계 API만 인증 필요하도록 접근 권한 완화 #71

### DIFF
--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/config/SecurityConfig.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/config/SecurityConfig.java
@@ -31,13 +31,15 @@ public class SecurityConfig {
 
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+
+                        // 🔒 인증 필요 API만 명시
                         .requestMatchers(
-                                "/api/auth/**",           // 로그인/회원가입
-                                "/swagger-ui/**",
-                                "/swagger-ui.html",
-                                "/v3/api-docs/**"
-                        ).permitAll()                    // 누구라도 접근 가능
-                        .anyRequest().authenticated()    // 그 외는 인증 필요
+                                "/api/goal/**",
+                                "/api/goal-algorithm/**"
+                        ).authenticated()
+
+                        // 🔓 그 외 나머지는 전부 허용
+                        .anyRequest().permitAll()
                 )
 
                 // 🔥 JWT 필터 등록


### PR DESCRIPTION
## 개요
JWT 보안 정책 조정: 목표/통계 API만 인증 필요하도록 접근 권한 완화 #71

## 변경 범위
- [ ] Frontend
- [x] Backend
- [ ] Infra/Docs

## 관련 이슈
- Closes #71

## 변경 내용
- 기본적으로 모든 API 접근 허용하도록 변경
- 목표(goals), 통계(statistics) API에만 JWT 인증 요구
- 확장앱/웹 환경에서 공용 데이터 요청 시 인증 제약 제거
- 서비스 접근성 개선 및 초기 개발 단계 테스트 용이성 향상


## 체크리스트
- [x] 로컬 빌드/테스트 통과 (frontend / backend)
- [ ] 브레이킹 체인지 시 문서 업데이트
- [x] 라벨/프로젝트/마일스톤 지정

## 스크린샷/로그 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* API 엔드포인트 인증 정책이 조정되었습니다. 목표 관련 엔드포인트(/api/goal/**, /api/goal-algorithm/**)는 인증이 필요하며, 기타 모든 엔드포인트는 인증 없이 접근 가능하도록 변경되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->