### PR TITLE
feat(backend): [Backend] Goal API 추가 구현(기간 + 날짜 기반 기준 조회) #74

### DIFF
--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/controller/GoalController.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/controller/GoalController.java
@@ -1,14 +1,17 @@
 package com.errorterry.algotrack_backend_spring.controller;
 
+import com.errorterry.algotrack_backend_spring.domain.GoalPeriod;
 import com.errorterry.algotrack_backend_spring.dto.GoalCreateRequestDto;
 import com.errorterry.algotrack_backend_spring.dto.GoalResponseDto;
 import com.errorterry.algotrack_backend_spring.security.AuthUser;
 import com.errorterry.algotrack_backend_spring.service.GoalService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
+import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -40,6 +43,25 @@ public class GoalController {
         return ResponseEntity
                 .created(URI.create("/api/goal/" + created.getGoalId()))
                 .body(created);
+    }
+
+    // 기간 + 날짜 기준 Goal 조회
+    // - 주간: GET /api/goal/search?goalPeriod=WEEK&startDate=2025-11-17&endDate=2025-11-23
+    // - 일간: GET /api/goal/search?goalPeriod=DAY&startDate=2025-11-20
+    @GetMapping("/search")
+    public ResponseEntity<List<GoalResponseDto>> getMyGoalsByDate(
+            @RequestParam("goalPeriod") GoalPeriod goalPeriod,
+            @RequestParam("startDate")
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(value = "endDate", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate
+    ) {
+
+        Integer userId = AuthUser.getUserId();
+
+        List<GoalResponseDto> results = goalService.getGoalsByPeriodAndDate(userId, goalPeriod, startDate, endDate);
+
+        return ResponseEntity.ok(results);
     }
 
 }

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/repository/GoalRepository.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/repository/GoalRepository.java
@@ -1,13 +1,30 @@
 package com.errorterry.algotrack_backend_spring.repository;
 
 import com.errorterry.algotrack_backend_spring.domain.Goal;
+import com.errorterry.algotrack_backend_spring.domain.GoalPeriod;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface GoalRepository extends JpaRepository<Goal, Integer> {
 
     // user_id 기준 Goal 목록 조회
     List<Goal> findByUserUserId(Integer userId);
+
+    // 주간 목표 : created_at이 시작일 ~ 종료일 사이인 Goal 목록 조회
+    List<Goal> findByUserUserIdAndGoalPeriodAndCreateAtBetween(
+            Integer userId,
+            GoalPeriod goalPeriod,
+            LocalDate startDate,
+            LocalDate endDate
+    );
+
+    // 일간 목표 : created_at이 특정 날짜와 같은 Goal 목록 조회
+    List<Goal> findByUserUserIdAndGoalPeriodAndCreateAt(
+      Integer userId,
+      GoalPeriod goalPeriod,
+      LocalDate targetDate
+    );
 
 }

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/service/GoalService.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/service/GoalService.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -65,6 +66,54 @@ public class GoalService {
         // 생성된 Goal 반환
         return GoalResponseDto.from(savedGoal);
 
+    }
+
+    // 기간 + 날짜 기준 Goal 조회
+    @Transactional(readOnly = true)
+    public List<GoalResponseDto> getGoalsByPeriodAndDate(
+            Integer userId,
+            GoalPeriod goalPeriod,
+            LocalDate startDate,
+            LocalDate endDate       // goalPeriod가 DAY일 때는 null 가능
+    ) {
+
+        if (startDate == null) {
+            throw new IllegalArgumentException("조회 시작 날짜가 비어있습니다.");
+        }
+
+        List<Goal> goals;
+
+        // 주간 목표
+        if (goalPeriod == GoalPeriod.WEEK) {
+            if (endDate == null) {
+                throw new IllegalArgumentException("조회 끝 날짜가 비어있습니다.");
+            }
+
+            if (endDate.isBefore(startDate)) {
+                throw new IllegalArgumentException("끝 날짜가 시작 날짜보다 빠릅니다.");
+            }
+
+            goals = goalRepository.findByUserUserIdAndGoalPeriodAndCreateAtBetween(
+                    userId,
+                    GoalPeriod.WEEK,
+                    startDate,
+                    endDate
+            );
+
+        // 일간 목표
+        } else if (goalPeriod == GoalPeriod.DAY) {
+            goals = goalRepository.findByUserUserIdAndGoalPeriodAndCreateAt(
+                    userId,
+                    GoalPeriod.DAY,
+                    startDate
+            );
+        } else {
+            throw new IllegalArgumentException("목표 기간 오류");
+        }
+
+        return goals.stream()
+                .map(GoalResponseDto::from)
+                .collect(Collectors.toList());
     }
 
 }


### PR DESCRIPTION
## 개요
Goal API 추가 구현(기간 + 날짜 기반 기준 조회)

## 변경 범위
- [ ] Frontend
- [x] Backend
- [ ] Infra/Docs

## 관련 이슈
- Closes #74 

## 변경 내용
- 주간(week) 목표 조회 : createdAt이 주 시작~종료일 사이인 Goal 조회
- 일간(day) 목표 조회 : createdAt이 특정 날짜와 일치하는 Goal 조회
- GET /api/goal/search 추가

## 체크리스트
- [x] 로컬 빌드/테스트 통과 (frontend / backend)
- [ ] 브레이킹 체인지 시 문서 업데이트
- [x] 라벨/프로젝트/마일스톤 지정

## 스크린샷/로그 (선택)
