### PR TITLE
feat(backend): [Backend] 목표 조회 응답 구조 개선 및 월별 목표 조회 기능 추가 #76

### DIFF
--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/controller/GoalController.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/controller/GoalController.java
@@ -3,6 +3,7 @@ package com.errorterry.algotrack_backend_spring.controller;
 import com.errorterry.algotrack_backend_spring.domain.GoalPeriod;
 import com.errorterry.algotrack_backend_spring.dto.GoalCreateRequestDto;
 import com.errorterry.algotrack_backend_spring.dto.GoalResponseDto;
+import com.errorterry.algotrack_backend_spring.dto.GoalWithAlgorithmsResponseDto;
 import com.errorterry.algotrack_backend_spring.security.AuthUser;
 import com.errorterry.algotrack_backend_spring.service.GoalService;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +22,7 @@ public class GoalController {
 
     private final GoalService goalService;
 
-    // 인증된 사용자 자신의 Goal 조회
+    // 인증된 사용자 자신의 Goal 조회 (목표 알고리즘 X)
     @GetMapping
     public ResponseEntity<List<GoalResponseDto>> getMyGoals() {
 
@@ -45,11 +46,11 @@ public class GoalController {
                 .body(created);
     }
 
-    // 기간 + 날짜 기준 Goal 조회
+    // 기간 + 날짜 기준 Goal 조회 (일간/주간) + GoalAlgorithm 포함
     // - 주간: GET /api/goal/search?goalPeriod=WEEK&startDate=2025-11-17&endDate=2025-11-23
     // - 일간: GET /api/goal/search?goalPeriod=DAY&startDate=2025-11-20
     @GetMapping("/search")
-    public ResponseEntity<List<GoalResponseDto>> getMyGoalsByDate(
+    public ResponseEntity<List<GoalWithAlgorithmsResponseDto>> getMyGoalsByDate(
             @RequestParam("goalPeriod") GoalPeriod goalPeriod,
             @RequestParam("startDate")
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
@@ -59,7 +60,24 @@ public class GoalController {
 
         Integer userId = AuthUser.getUserId();
 
-        List<GoalResponseDto> results = goalService.getGoalsByPeriodAndDate(userId, goalPeriod, startDate, endDate);
+        List<GoalWithAlgorithmsResponseDto> results =
+                goalService.getGoalsByPeriodAndDate(userId, goalPeriod, startDate, endDate);
+
+        return ResponseEntity.ok(results);
+    }
+
+    // 월별 목표 조회 + GoalAlgorithm 포함
+    // GET /api/goal/month?year=2025&month=11
+    @GetMapping("/month")
+    public ResponseEntity<List<GoalWithAlgorithmsResponseDto>> getMyGoalsByMonth(
+            @RequestParam("year") int year,
+            @RequestParam("month") int month
+    ) {
+
+        Integer userId = AuthUser.getUserId();
+
+        List<GoalWithAlgorithmsResponseDto> results =
+                goalService.getGoalsByMonth(userId, year, month);
 
         return ResponseEntity.ok(results);
     }

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/dto/GoalAlgorithmResponseDto.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/dto/GoalAlgorithmResponseDto.java
@@ -10,6 +10,7 @@ public class GoalAlgorithmResponseDto {
     private Integer goalAlgorithmId;
     private Integer goalId;
     private Integer algorithmId;
+    private String algorithmName;
     private Integer goalProblem;
     private Integer solveProblem;
 
@@ -18,6 +19,7 @@ public class GoalAlgorithmResponseDto {
                 .goalAlgorithmId(goalAlgorithm.getGoalAlgorithmId())
                 .goalId(goalAlgorithm.getGoal().getGoalId())
                 .algorithmId(goalAlgorithm.getAlgorithm().getAlgorithmId())
+                .algorithmName(goalAlgorithm.getAlgorithm().getAlgorithmName())
                 .goalProblem(goalAlgorithm.getGoalProblem())
                 .solveProblem(goalAlgorithm.getSolveProblem())
                 .build();

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/dto/GoalWithAlgorithmsResponseDto.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/dto/GoalWithAlgorithmsResponseDto.java
@@ -1,0 +1,37 @@
+package com.errorterry.algotrack_backend_spring.dto;
+
+import com.errorterry.algotrack_backend_spring.domain.Goal;
+import com.errorterry.algotrack_backend_spring.domain.GoalPeriod;
+import com.errorterry.algotrack_backend_spring.domain.GoalAlgorithm;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor @Builder
+public class GoalWithAlgorithmsResponseDto {
+
+    private Integer goalId;
+    private Integer userId;
+    private GoalPeriod goalPeriod;
+    private LocalDate createAt;
+
+    private List<GoalAlgorithmResponseDto> goalAlgorithms;
+
+    public static GoalWithAlgorithmsResponseDto from(Goal goal, List<GoalAlgorithm> goalAlgorithms) {
+        return GoalWithAlgorithmsResponseDto.builder()
+                .goalId(goal.getGoalId())
+                .userId(goal.getUser().getUserId())
+                .goalPeriod(goal.getGoalPeriod())
+                .createAt(goal.getCreateAt())
+                .goalAlgorithms(
+                        goalAlgorithms.stream()
+                                .map(GoalAlgorithmResponseDto::from)
+                                .collect(Collectors.toList())
+                )
+                .build();
+    }
+
+}

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/repository/GoalAlgorithmRepository.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/repository/GoalAlgorithmRepository.java
@@ -11,6 +11,9 @@ public interface GoalAlgorithmRepository extends JpaRepository<GoalAlgorithm, In
     // goal_id 기준 GoalAlgorithm 목록 조회
     List<GoalAlgorithm> findByGoalGoalId(Integer goalId);
 
+    // 여러 goal_id에 대한 GoalAlgorithm 한 번에 조회
+    List<GoalAlgorithm> findByGoalGoalIdIn(List<Integer> goalIds);
+
     // goal_id + algorithm_name 기준 단일 조회
     Optional<GoalAlgorithm> findByGoalGoalIdAndAlgorithmAlgorithmName(Integer goalId, String algorithmName);
 

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/repository/GoalRepository.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/repository/GoalRepository.java
@@ -22,9 +22,16 @@ public interface GoalRepository extends JpaRepository<Goal, Integer> {
 
     // 일간 목표 : created_at이 특정 날짜와 같은 Goal 목록 조회
     List<Goal> findByUserUserIdAndGoalPeriodAndCreateAt(
-      Integer userId,
-      GoalPeriod goalPeriod,
-      LocalDate targetDate
+            Integer userId,
+            GoalPeriod goalPeriod,
+            LocalDate targetDate
+    );
+
+    // 월별 목표 : created_at이 월 범위에 포함되는 Goal 목록 조회
+    List<Goal> findByUserUserIdAndCreateAtBetween(
+            Integer userId,
+            LocalDate startDate,
+            LocalDate endDate
     );
 
 }

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/service/GoalService.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/service/GoalService.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -20,7 +20,7 @@ public class GoalService {
     private final AlgorithmRepository algorithmRepository;
     private final GoalAlgorithmRepository goalAlgorithmRepository;
 
-    // 사용자별(user_id) Goal 조회
+    // 사용자별(user_id) Goal 조회 (목표 알고리즘 포함 X)
     @Transactional(readOnly = true)
     public List<GoalResponseDto> getGoalsByUserId(Integer userId) {
         return goalRepository.findByUserUserId(userId)
@@ -68,9 +68,40 @@ public class GoalService {
 
     }
 
-    // 기간 + 날짜 기준 Goal 조회
+    // 공통 : Goal 리스트 + GoalAlgorithm 리스트 묶어서 DTO 변환
     @Transactional(readOnly = true)
-    public List<GoalResponseDto> getGoalsByPeriodAndDate(
+    protected List<GoalWithAlgorithmsResponseDto> toGoalWithAlgorithmsDtos(List<Goal> goals) {
+        if (goals.isEmpty()) {
+            return List.of();
+        }
+
+        // goalId 목록 추출
+        List<Integer> goalIds = goals.stream()
+                .map(Goal::getGoalId)
+                .collect(Collectors.toList());
+
+        // 해당 goalId들에 대한 GoalAlgorithm 한 번에 조회
+        List<GoalAlgorithm> allGoalAlgorithms =
+                goalAlgorithmRepository.findByGoalGoalIdIn(goalIds);
+
+        // goalId 기준으로 묶기
+        Map<Integer, List<GoalAlgorithm>> algorithmsByGoalId =
+                allGoalAlgorithms.stream()
+                        .collect(Collectors.groupingBy(ga -> ga.getGoal().getGoalId()));
+
+        // Goal + 매칭되는 GoalAlgorithm 목록으로 DTO 생성
+        return goals.stream()
+                .map(goal -> {
+                    List<GoalAlgorithm> goalAlgorithms =
+                            algorithmsByGoalId.getOrDefault(goal.getGoalId(), List.of());
+                    return GoalWithAlgorithmsResponseDto.from(goal, goalAlgorithms);
+                })
+                .collect(Collectors.toList());
+    }
+
+    // 기간 + 날짜 기준 Goal 조회 (일간/주간) + GoalAlgorithm 포함
+    @Transactional(readOnly = true)
+    public List<GoalWithAlgorithmsResponseDto> getGoalsByPeriodAndDate(
             Integer userId,
             GoalPeriod goalPeriod,
             LocalDate startDate,
@@ -111,9 +142,30 @@ public class GoalService {
             throw new IllegalArgumentException("목표 기간 오류");
         }
 
-        return goals.stream()
-                .map(GoalResponseDto::from)
-                .collect(Collectors.toList());
+        return toGoalWithAlgorithmsDtos(goals);
+    }
+
+    // 월별 목표 조회 + GoalAlgorithm 포함
+    @Transactional(readOnly = true)
+    public List<GoalWithAlgorithmsResponseDto> getGoalsByMonth(
+            Integer userId,
+            int year,
+            int month
+    ) {
+        if (month < 1 || month > 12) {
+            throw new IllegalArgumentException("month 기간 오류");
+        }
+
+        LocalDate startDate = LocalDate.of(year, month, 1);
+        LocalDate endDate = startDate.withDayOfMonth(startDate.lengthOfMonth());
+
+        List<Goal> goals = goalRepository.findByUserUserIdAndCreateAtBetween(
+                userId,
+                startDate,
+                endDate
+        );
+
+        return toGoalWithAlgorithmsDtos(goals);
     }
 
 }


### PR DESCRIPTION
## 개요
목표 조회 응답 구조 개선 및 월별 목표 조회 기능 추가

## 변경 범위
- [ ] Frontend
- [x] Backend
- [ ] Infra/Docs

## 관련 이슈
- Closes #76 

## 변경 내용
- 요약:- 일간/주간 목표 조회 시 GoalAlgorithm 목록 포함하도록 개선
- GoalWithAlgorithmsResponseDto 생성 및 조회 API로 반환하도록 변경
- 월별 목표 조회 API 추가
- GoalAlgorithmResponseDto에 algorithmName 추가
- GoalAlgorithmRepository에 findByGoalGoalIdIn 추가하여 N+1 해결

## 체크리스트
- [x] 로컬 빌드/테스트 통과 (frontend / backend)
- [ ] 브레이킹 체인지 시 문서 업데이트
- [x] 라벨/프로젝트/마일스톤 지정

## 스크린샷/로그 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 특정 연월의 목표 조회를 위한 월별 조회 기능 추가
  * 날짜 기반 목표 조회 시 연관된 알고리즘 정보 포함
  * 알고리즘 이름 정보가 목표 조회 응답에 추가됨

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->