### PR TITLE
feat(backend): [Backend] Goal 생성 로직 개선 (WEEK/ DAY 단일 Goal 유지 + GoalAlgorithm 중첩 추가) #80

### DIFF
--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/dto/GoalCreateRequestDto.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/dto/GoalCreateRequestDto.java
@@ -3,6 +3,7 @@ package com.errorterry.algotrack_backend_spring.dto;
 import com.errorterry.algotrack_backend_spring.domain.GoalPeriod;
 import lombok.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Getter @Setter
@@ -10,6 +11,7 @@ import java.util.List;
 public class GoalCreateRequestDto {
 
     private GoalPeriod goalPeriod;
+    private LocalDate targetDate;
     private List<GoalAlgorithmCreateRequestDto> goalAlgorithms;
 
 }

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/repository/GoalAlgorithmRepository.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/repository/GoalAlgorithmRepository.java
@@ -17,4 +17,7 @@ public interface GoalAlgorithmRepository extends JpaRepository<GoalAlgorithm, In
     // goal_id + algorithm_name 기준 단일 조회
     Optional<GoalAlgorithm> findByGoalGoalIdAndAlgorithmAlgorithmName(Integer goalId, String algorithmName);
 
+    // goal_id + algorithm_id 기준 단일 조회
+    Optional<GoalAlgorithm> findByGoalGoalIdAndAlgorithmAlgorithmId(Integer goalId, Integer algorithmId);
+
 }


### PR DESCRIPTION
## 개요
Goal 생성 로직 개선 (WEEK/ DAY 단일 Goal 유지 + GoalAlgorithm 중첩 추가)

## 변경 범위
- [ ] Frontend
- [x] Backend
- [ ] Infra/Docs

## 관련 이슈
- Closes #80 

## 변경 내용
- WEEK / DAY 기준으로 기존 Goal 재사용하도록 변경
- GoalAlgorithm 중복 시 goalProblem 누적 처리
- 목표 생성 기준 날짜를 targetDate(프론트 입력)로 통일
- Repository/DTO/Service 관련 코드 수정

## 체크리스트
- [x] 로컬 빌드/테스트 통과 (frontend / backend)
- [ ] 브레이킹 체인지 시 문서 업데이트
- [x] 라벨/프로젝트/마일스톤 지정

## 스크린샷/로그 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **새 기능**
  * 목표에 목표 달성 날짜를 설정할 수 있도록 개선
  * 주간 및 일간 기간별로 목표를 자동으로 구분 및 관리
  * 같은 기간 내 중복된 목표 자동 통합으로 효율성 향상

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->