### PR TITLE
feat(backend): [Backend] 목표(주간/일간) JPA 도메인 전면 개편 #84

### DIFF
--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/domain/DailyGoal.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/domain/DailyGoal.java
@@ -1,0 +1,66 @@
+package com.errorterry.algotrack_backend_spring.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(
+        name = "daily_goal",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uq_daily_goal",
+                        columnNames = {"weekly_goal_id", "algorithm_id", "goal_date"}
+                )
+        }
+)
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor @Builder
+@DynamicInsert
+public class DailyGoal {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "daily_goal_id")
+    private Integer dailyGoalId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(
+            name = "weekly_goal_id",
+            nullable = false,
+            foreignKey = @ForeignKey(name = "fk_daily_goal_weekly_goal")
+    )
+    private WeeklyGoal weeklyGoal;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(
+            name = "algorithm_id",
+            nullable = false,
+            foreignKey = @ForeignKey(name = "fk_daily_goal_algorithm")
+    )
+    private Algorithm algorithm;
+
+    @Column(
+            name = "goal_date",
+            nullable = false,
+            columnDefinition = "date"
+    )
+    private LocalDate goalDate;
+
+    @Column(
+            name = "goal_count",
+            nullable = false,
+            columnDefinition = "INT CHECK (goal_count) >= 0"
+    )
+    private Integer goalCount;
+
+    @Column(
+            name = "solve_count",
+            nullable = false,
+            columnDefinition = "INT DEFAULT 0 CHECK (solve_count >= 0 and solve_count <= goal_count)"
+    )
+    private Integer solveCount;
+
+}

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/domain/WeeklyGoal.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/domain/WeeklyGoal.java
@@ -1,0 +1,44 @@
+package com.errorterry.algotrack_backend_spring.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(
+        name = "weekly_goal",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uq_weekly_goal",
+                        columnNames = {"user_id", "week_start_date"}
+                )
+        }
+)
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor @Builder
+@DynamicInsert
+public class WeeklyGoal {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "weekly_goal_id")
+    private Integer weeklyGoalId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(
+            name = "user_id",
+            nullable = false,
+            foreignKey = @ForeignKey(name = "fk_weekly_goal_users")
+    )
+    private User user;
+
+    @Column(
+            name = "week_start_date",
+            nullable = false,
+            columnDefinition = "date"
+    )
+    private LocalDate weekStartDate;
+
+}


### PR DESCRIPTION
## 개요
- 새로운 목표 구조(주간/일간 목표) 적용을 위해 `WeeklyGoal`, `DailyGoal` JPA 엔티티를 추가
- 기존 Goal/GoalAlgorithm 구조는 점진적으로 제거 예정

## 변경 범위
- [ ] Frontend
- [x] Backend
- [ ] Infra/Docs

## 관련 이슈
- Closes #84 

## 변경 내용
- weekly_goal, daily_goal 테이블 구조 기반으로 JPA 엔티티 생성
- User, Algorithm 연관관계 매핑 적용
- UNIQUE, FK 제약조건 반영
- 기존 Goal/GoalAlgorithm 엔티티는 향후 일괄 삭제 예정

## 체크리스트
- [x] 로컬 빌드/테스트 통과 (frontend / backend)
- [ ] 브레이킹 체인지 시 문서 업데이트
- [x] 라벨/프로젝트/마일스톤 지정

## 스크린샷/로그 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새 기능
* 주간 및 일일 알고리즘 학습 목표 설정 및 진행 현황 추적을 위한 백엔드 기반 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->