### PR TITLE
feat(backend): [Backend] 목표 생성 API 구현 (weekly_goal / daily_goal 생성·갱신) #94

### DIFF
--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/controller/WeeklyGoalController.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/controller/WeeklyGoalController.java
@@ -1,5 +1,7 @@
 package com.errorterry.algotrack_backend_spring.controller;
 
+import com.errorterry.algotrack_backend_spring.dto.WeeklyGoalCreateRequestDto;
+import com.errorterry.algotrack_backend_spring.dto.WeeklyGoalSaveResponseDto;
 import com.errorterry.algotrack_backend_spring.dto.WeeklyGoalSummaryResponseDto;
 import com.errorterry.algotrack_backend_spring.security.AuthUser;
 import com.errorterry.algotrack_backend_spring.service.WeeklyGoalService;
@@ -32,6 +34,21 @@ public class WeeklyGoalController {
                 weeklyGoalService.getWeeklySummary(userId, weekStartDate);
 
         return ResponseEntity.ok(response);
+    }
+
+    // 주간 목표 생성/갱신 API
+    @PostMapping("/weekly")
+    public ResponseEntity<WeeklyGoalSaveResponseDto> createOrUpdateWeeklyGoal(
+            @RequestBody WeeklyGoalCreateRequestDto request
+    ) {
+
+        Integer userId = AuthUser.getUserId();
+
+        WeeklyGoalSaveResponseDto response =
+                weeklyGoalService.createOrUpdateWeeklyGoal(userId, request);
+
+        return ResponseEntity.ok(response);
+
     }
 
 }

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/dto/WeeklyGoalAlgorithmPlanRequestDto.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/dto/WeeklyGoalAlgorithmPlanRequestDto.java
@@ -1,0 +1,12 @@
+package com.errorterry.algotrack_backend_spring.dto;
+
+import lombok.*;
+
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor @Builder
+public class WeeklyGoalAlgorithmPlanRequestDto {
+
+    private Integer algorithmId;
+    private int[] dailyPlan;
+
+}

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/dto/WeeklyGoalCreateRequestDto.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/dto/WeeklyGoalCreateRequestDto.java
@@ -1,0 +1,15 @@
+package com.errorterry.algotrack_backend_spring.dto;
+
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor @Builder
+public class WeeklyGoalCreateRequestDto {
+
+    private LocalDate weekStartDate;
+    private List<WeeklyGoalAlgorithmPlanRequestDto> algorithms;
+
+}

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/dto/WeeklyGoalSaveResponseDto.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/dto/WeeklyGoalSaveResponseDto.java
@@ -1,0 +1,14 @@
+package com.errorterry.algotrack_backend_spring.dto;
+
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor @Builder
+public class WeeklyGoalSaveResponseDto {
+
+    private Integer weeklyGoalId;
+    private LocalDate weekStartDate;
+
+}

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/repository/DailyGoalRepository.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/repository/DailyGoalRepository.java
@@ -3,11 +3,20 @@ package com.errorterry.algotrack_backend_spring.repository;
 import com.errorterry.algotrack_backend_spring.domain.DailyGoal;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 public interface DailyGoalRepository extends JpaRepository<DailyGoal, Integer> {
 
     // 특정 weekly_goal에 속한 일간 목표 전체 조회
     List<DailyGoal> findByWeeklyGoalWeeklyGoalId(Integer weeklyGoalId);
+
+    // weekly_goal_id + algorithm_id + goal_date 기준 단일 일간 목표 조회
+    Optional<DailyGoal> findByWeeklyGoalWeeklyGoalIdAndAlgorithmAlgorithmIdAndGoalDate(
+            Integer weeklyGoalId,
+            Integer algorithmId,
+            LocalDate goalDate
+    );
 
 }

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/service/WeeklyGoalService.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/service/WeeklyGoalService.java
@@ -2,10 +2,12 @@ package com.errorterry.algotrack_backend_spring.service;
 
 import com.errorterry.algotrack_backend_spring.domain.Algorithm;
 import com.errorterry.algotrack_backend_spring.domain.DailyGoal;
+import com.errorterry.algotrack_backend_spring.domain.User;
 import com.errorterry.algotrack_backend_spring.domain.WeeklyGoal;
-import com.errorterry.algotrack_backend_spring.dto.WeeklyGoalAlgorithmSummaryDto;
-import com.errorterry.algotrack_backend_spring.dto.WeeklyGoalSummaryResponseDto;
+import com.errorterry.algotrack_backend_spring.dto.*;
+import com.errorterry.algotrack_backend_spring.repository.AlgorithmRepository;
 import com.errorterry.algotrack_backend_spring.repository.DailyGoalRepository;
+import com.errorterry.algotrack_backend_spring.repository.UserRepository;
 import com.errorterry.algotrack_backend_spring.repository.WeeklyGoalRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,6 +24,8 @@ public class WeeklyGoalService {
 
     private final WeeklyGoalRepository weeklyGoalRepository;
     private final DailyGoalRepository dailyGoalRepository;
+    private final UserRepository userRepository;
+    private final AlgorithmRepository algorithmRepository;
 
     // 주간 목표 요약 조회
     // userId + weekStartDate 기준으로 WeeklyGoal 찾기
@@ -97,6 +101,107 @@ public class WeeklyGoalService {
         return WeeklyGoalSummaryResponseDto.builder()
                 .weekStartDate(weekStartDate)
                 .algorithms(algorithmDtos)
+                .build();
+    }
+
+    // 주간 목표 생성/갱신
+    // - (userId, weekStartDate) 기준 WeeklyGoal 조회 후, 없으면 생성
+    // - algorithms[algorithmId + dailyPlan[7]] 기준으로 DailyGoal 생성/갱신
+    @Transactional
+    public WeeklyGoalSaveResponseDto createOrUpdateWeeklyGoal(
+            Integer userId,
+            WeeklyGoalCreateRequestDto request
+    ) {
+
+        if (request == null) {
+            throw new IllegalArgumentException("요청이 비어있습니다.");
+        }
+
+        LocalDate weekStartDate = request.getWeekStartDate();
+        if (weekStartDate == null) {
+            throw new IllegalArgumentException("weekStartDate가 비어있습니다.");
+        }
+
+        if (request.getAlgorithms() == null || request.getAlgorithms().isEmpty()) {
+            throw new IllegalArgumentException("algorithms가 비어있습니다.");
+        }
+
+        // 1. User 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        // 2. weekly_goal 조회 또는 생성
+        WeeklyGoal weeklyGoal = weeklyGoalRepository
+                .findByUserUserIdAndWeekStartDate(userId, weekStartDate)
+                .orElseGet(() -> {
+                    WeeklyGoal newWeeklyGoal = WeeklyGoal.builder()
+                            .user(user)
+                            .weekStartDate(weekStartDate)
+                            .build();
+                    return weeklyGoalRepository.save(newWeeklyGoal);
+                });
+
+        Integer weeklyGoalId = weeklyGoal.getWeeklyGoalId();
+
+        // 3. 알고리즘별 dailyPlan 처리
+        for (WeeklyGoalAlgorithmPlanRequestDto algDto : request.getAlgorithms()) {
+
+            Integer algorithmId = algDto.getAlgorithmId();
+            if (algorithmId == null) {
+                throw new IllegalArgumentException("algorithmId : null");
+            }
+
+            Algorithm algorithm = algorithmRepository.findById(algorithmId)
+                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 algorithmId"));
+            int[] dailyPlan = algDto.getDailyPlan();
+            if (dailyPlan == null || dailyPlan.length != 7) {
+                throw new IllegalArgumentException("dailyPlan 길이 오류 (7이 아님)");
+            }
+
+            for (int i = 0; i < 7; i++) {
+                int plan = dailyPlan[i];
+
+                if (plan < 0) {
+                    throw new IllegalArgumentException("dailyPlan 값 오류");
+                }
+
+                // dailyPlan 값 0 : pass
+                if (plan == 0) {
+                    continue;
+                }
+
+                LocalDate goalDate = weekStartDate.plusDays(i);
+
+                // 기존 daily_goal 존재 여부 확인
+                Optional<DailyGoal> existingOpt =
+                        dailyGoalRepository.findByWeeklyGoalWeeklyGoalIdAndAlgorithmAlgorithmIdAndGoalDate(
+                                weeklyGoalId,
+                                algorithmId,
+                                goalDate
+                        );
+
+                if (existingOpt.isPresent()) {
+                    // 기존 daily_goal -> goal_count 누적
+                    DailyGoal existing = existingOpt.get();
+                    int currentGoalCount = existing.getGoalCount() != null ? existing.getGoalCount() : 0;
+                    existing.setGoalCount(currentGoalCount + plan);
+                } else {
+                    // 새 daily_goal 생성
+                    DailyGoal newDailyGoal = DailyGoal.builder()
+                            .weeklyGoal(weeklyGoal)
+                            .algorithm(algorithm)
+                            .goalDate(goalDate)
+                            .goalCount(plan)
+                            .solveCount(0)
+                            .build();
+                    dailyGoalRepository.save(newDailyGoal);
+                }
+            }
+        }
+
+        return WeeklyGoalSaveResponseDto.builder()
+                .weeklyGoalId(weeklyGoalId)
+                .weekStartDate(weekStartDate)
                 .build();
     }
 


### PR DESCRIPTION
## 개요
주간 목표(weekly_goal)와 일간 목표(daily_goal)를 생성·갱신하는 API 구현

프론트에서 전달하는 `weekStartDate`와 `algorithms(dailyPlan[7])`를 기반으로
사용자의 주간/일간 목표 데이터를 생성하거나 누적 갱신합니다.

## 변경 범위
- [ ] Frontend
- [x] Backend
- [ ] Infra/Docs

## 관련 이슈
- Closes #94 

## 변경 내용
- WeeklyGoalCreateRequestDto, WeeklyGoalAlgorithmPlanRequestDto, WeeklyGoalSaveResponseDto 추가
- WeeklyGoalService에 주간 목표 생성/갱신(createOrUpdateWeeklyGoal) 로직 구현
- weekly_goal 존재 시 재사용, 미존재 시 자동 생성
- dailyPlan[7] 기반 daily_goal 생성/갱신 처리
  - dailyPlan[i] > 0 → 기존 goal_count 누적 또는 신규 생성
  - dailyPlan[i] == 0 → 패스
- DailyGoalRepository 조회 메서드 추가
- WeeklyGoalController에 `/weekly` POST 엔드포인트 추가

## 체크리스트
- [x] 로컬 빌드/테스트 통과 (frontend / backend)
- [ ] 브레이킹 체인지 시 문서 업데이트
- [x] 라벨/프로젝트/마일스톤 지정

## 스크린샷/로그 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
- 주간 목표 관리 기능이 추가되었습니다. 사용자가 주차별로 각 알고리즘에 대한 일일 계획을 설정하여 주간 목표를 생성하고 업데이트할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->