### PR TITLE
feat(backend): [Backend] solved_log 기록 및 daily_goal의 solve_count 증가 API 구현 #100

### DIFF
--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/controller/SolvedLogController.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/controller/SolvedLogController.java
@@ -1,0 +1,31 @@
+package com.errorterry.algotrack_backend_spring.controller;
+
+import com.errorterry.algotrack_backend_spring.dto.SolvedLogRequestDto;
+import com.errorterry.algotrack_backend_spring.security.AuthUser;
+import com.errorterry.algotrack_backend_spring.service.SolvedLogService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/solve-log")
+@RequiredArgsConstructor
+public class SolvedLogController {
+
+    private final SolvedLogService solvedLogService;
+
+    // 문제 해결 로그 기록 + 일간 목표 solve_count 증가 API
+    // - 요청 : POST /api/solve-log
+    // - body : { algorithmName, problemId, solvedDate, problemTier }
+    // - 응답 : 200 OK
+    @PostMapping
+    public ResponseEntity<Void> recordSolved(@RequestBody SolvedLogRequestDto request) {
+
+        Integer userId = AuthUser.getUserId();
+
+        solvedLogService.recordSolvedAndIncreaseDailyGoal(userId, request);
+
+        return ResponseEntity.ok().build();
+    }
+
+}

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/domain/SolvedLog.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/domain/SolvedLog.java
@@ -1,0 +1,58 @@
+package com.errorterry.algotrack_backend_spring.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(
+        name = "solved_log",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uq_solved_log",
+                        columnNames = {"user_id", "problem_id"}
+                )
+        }
+)
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor @Builder
+@DynamicInsert
+public class SolvedLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "solved_log_id")
+    private Integer solvedLogId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(
+            name = "user_id",
+            nullable = false,
+            foreignKey = @ForeignKey(name = "fk_solved_log_users")
+    )
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(
+            name = "algorithm_id",
+            nullable = false,
+            foreignKey = @ForeignKey(name = "fk_solved_log_algorithm")
+    )
+    private Algorithm algorithm;
+
+    @Column(name = "problem_id", nullable = false)
+    private Integer problemId;
+
+    @Column(name = "solved_date", nullable = false)
+    private LocalDate solvedDate;
+
+    @Column(
+            name = "problem_tier",
+            nullable = false,
+            columnDefinition = "text default 'X' check ( problem_tier in ('X', 'Unrated', 'Bronze', 'Silver', 'Gold', 'Platinum', 'Diamond', 'Ruby') )"
+    )
+    private String problemTier;
+
+}

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/dto/SolvedLogRequestDto.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/dto/SolvedLogRequestDto.java
@@ -1,0 +1,16 @@
+package com.errorterry.algotrack_backend_spring.dto;
+
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor @Builder
+public class SolvedLogRequestDto {
+
+    private String algorithmName;
+    private Integer problemId;
+    private LocalDate solvedDate;
+    private Integer problemTier;
+
+}

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/repository/AlgorithmRepository.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/repository/AlgorithmRepository.java
@@ -4,10 +4,14 @@ import com.errorterry.algotrack_backend_spring.domain.Algorithm;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface AlgorithmRepository extends JpaRepository<Algorithm, Integer> {
 
     // definition NOT NULL 조회
     List<Algorithm> findByDefinitionIsNotNull();
+
+    // algorithm_name 기준 알고리즘 조회
+    Optional<Algorithm> findByAlgorithmName(String algorithmName);
 
 }

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/repository/DailyGoalRepository.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/repository/DailyGoalRepository.java
@@ -19,4 +19,11 @@ public interface DailyGoalRepository extends JpaRepository<DailyGoal, Integer> {
             LocalDate goalDate
     );
 
+    // user_id + algorithm_id + goal_date 기준 단일 일간 목표 조회
+    Optional<DailyGoal> findByWeeklyGoalUserUserIdAndAlgorithmAlgorithmIdAndGoalDate(
+            Integer userId,
+            Integer algorithmId,
+            LocalDate goalDate
+    );
+
 }

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/repository/SolvedLogRepository.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/repository/SolvedLogRepository.java
@@ -1,0 +1,11 @@
+package com.errorterry.algotrack_backend_spring.repository;
+
+import com.errorterry.algotrack_backend_spring.domain.SolvedLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SolvedLogRepository extends JpaRepository<SolvedLog, Integer> {
+
+    // user_id + problem_id 기준으로 문제 해결 이력 존재 여부 조회
+    boolean existsByUserUserIdAndProblemId(Integer userId, Integer problemId);
+
+}

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/service/SolvedLogService.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/service/SolvedLogService.java
@@ -1,0 +1,113 @@
+package com.errorterry.algotrack_backend_spring.service;
+
+import com.errorterry.algotrack_backend_spring.domain.*;
+import com.errorterry.algotrack_backend_spring.dto.SolvedLogRequestDto;
+import com.errorterry.algotrack_backend_spring.repository.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class SolvedLogService {
+
+    private final SolvedLogRepository solvedLogRepository;
+    private final UserRepository userRepository;
+    private final AlgorithmRepository algorithmRepository;
+    private final DailyGoalRepository dailyGoalRepository;
+
+    // solved_log 기록 + daily_goal.solve_count 증가
+    // - userId + problemId 기준으로 기존 해결 이력이 있으면 PASS
+    // - 없으면
+    //  1) solved_log insert
+    //  2) 해당 날짜/알고리즘 daily_goal이 있으면 solve_count +1
+    @Transactional
+    public void recordSolvedAndIncreaseDailyGoal(
+            Integer userId,
+            SolvedLogRequestDto request
+    ) {
+        if (request == null) {
+            throw new IllegalArgumentException("요청 값 NULL 오류");
+        }
+
+        String algorithmName = request.getAlgorithmName();
+        Integer problemId = request.getProblemId();
+        LocalDate solvedDate = request.getSolvedDate();
+
+        if (algorithmName == null || algorithmName.isBlank()) {
+            throw new IllegalArgumentException("algorithmName 값 NULL 오류");
+        }
+        if (problemId == null) {
+            throw new IllegalArgumentException("problemId 값 NULL 오류");
+        }
+        if (solvedDate == null) {
+            throw new IllegalArgumentException("solvedDate 값 NULL 오류");
+        }
+
+        // 1) 이미 기록된 해결 이력이 있는지 체크
+        boolean exists = solvedLogRepository.existsByUserUserIdAndProblemId(userId, problemId);
+        if (exists) {
+            // 이미 기록된 문제 -> solved_log / daily_goal 둘 다 PASS
+            return;
+        }
+
+        // 2) User / Algorithm 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자"));
+
+        Algorithm algorithm = algorithmRepository.findByAlgorithmName(algorithmName)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 알고리즘"));
+
+        Integer algorithmId = algorithm.getAlgorithmId();
+
+        // 3) problemTier : 정수 -> 문자열 변환
+        String problemTier = convertProblemTierToLabel(request.getProblemTier());
+
+        // 4) solved_log 신규 저장
+        SolvedLog solvedLog = SolvedLog.builder()
+                .user(user)
+                .algorithm(algorithm)
+                .problemId(problemId)
+                .solvedDate(solvedDate)
+                .problemTier(problemTier)
+                .build();
+
+        solvedLogRepository.save(solvedLog);
+
+        // 5) daily_goal 처리 (해당 날짜/알고리즘 목표가 있을 경우 solve_count +1)
+        dailyGoalRepository
+                .findByWeeklyGoalUserUserIdAndAlgorithmAlgorithmIdAndGoalDate(userId, algorithmId, solvedDate)
+                .ifPresent(dailyGoal -> {
+                    int current = dailyGoal.getSolveCount() != null ? dailyGoal.getSolveCount() : 0;
+                    dailyGoal.setSolveCount(current + 1);
+                });
+    }
+
+    // problemTier : 정수 -> 문자열 변환
+    private String convertProblemTierToLabel(Integer problemTier) {
+        if (problemTier == null) {
+            return "X";
+        }
+
+        int score = problemTier;
+
+        if (score <= 0) {
+            return "Unrated";
+        } else if (score <= 5) {
+            return "Bronze";
+        } else if (score <= 10) {
+            return "Silver";
+        } else if (score <= 15) {
+            return "Gold";
+        } else if (score <= 20) {
+            return "Platinum";
+        } else if (score <= 25) {
+            return "Diamond";
+        } else {
+            return "Ruby";
+        }
+    }
+
+}


### PR DESCRIPTION
## 개요
- solved_log 기록 및 daily_goal의 solve_count 증가 API 구현

## 변경 범위
- [ ] Frontend
- [x] Backend
- [ ] Infra/Docs

## 관련 이슈
- Closes #100 

## 변경 내용
- algorithmName 기반 Algorithm 조회로 구조 변경
- problemTier : 정수 -> 문자열 변환 로직 추가
- solved_log 중복 검사 후 첫 풀이만 저장
- daily_goal 존재 시 solve_count 자동 증가 처리

### 수정된 파일
- AlgorithmRepository
- DailyGoalRepository

### 신규 파일
- SolvedLog (Entity)
- SolvedLogRepository
- SolvedLogService
- SolvedLogController
- SolvedLogRequestDto

## 체크리스트
- [x] 로컬 빌드/테스트 통과 (frontend / backend)
- [ ] 브레이킹 체인지 시 문서 업데이트
- [x] 라벨/프로젝트/마일스톤 지정

## 스크린샷/로그 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* **문제 풀이 기록 API 추가**
  * 알고리즘 문제의 풀이 정보(문제명, 난이도, 풀이 날짜)를 기록할 수 있습니다.
  * 같은 문제의 중복 기록은 방지됩니다.
  * 기록 시 일일 목표가 자동으로 업데이트됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->