### PR TITLE
feat(backend): [Backend] Swagger Authorization(Bearer Token) 입력 기능 추가 #106

### DIFF
--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/config/SwaggerConfig.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/config/SwaggerConfig.java
@@ -1,6 +1,9 @@
 package com.errorterry.algotrack_backend_spring.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -12,7 +15,21 @@ public class SwaggerConfig {
 
     @Bean
     public OpenAPI openAPI() {
+
+        String schemeName = "BearerAuth";
+
         return new OpenAPI()
+                // SWAGGER 인증 버튼 생성 부분
+                .addSecurityItem(new SecurityRequirement().addList(schemeName))
+                .components(new Components()
+                        .addSecuritySchemes(schemeName,
+                                new SecurityScheme()
+                                        .name(schemeName)
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")
+                        )
+                )
                 // 현재 도메인(https://algotrack.store)을 기준으로 /api 같은 식으로 날림
                 // 완전 고정하고 싶으면: new Server().url("https://algotrack.store")
                 .servers(List.of(new Server().url("/")));


### PR DESCRIPTION
## 개요
- Swagger Authorization(Bearer Token) 입력 기능 추가

## 변경 범위
- [ ] Frontend
- [x] Backend
- [ ] Infra/Docs

## 관련 이슈
- Closes #106 

## 변경 내용
- Swagger에 Bearer Token 인증 스키마 추가
- Swagger UI 상단에 Authorize 버튼 활성화
- Authorization 헤더 자동 적용 기능 설정
- 기존 서버 URL 설정과 함께 SecurityScheme, SecurityRequirement 구성 추가

## 체크리스트
- [x] 로컬 빌드/테스트 통과 (frontend / backend)
- [ ] 브레이킹 체인지 시 문서 업데이트
- [x] 라벨/프로젝트/마일스톤 지정

## 스크린샷/로그 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * API 문서에서 Bearer 토큰 기반 인증 지원이 추가되었습니다. 이제 Swagger/OpenAPI 문서에서 JWT 토큰을 사용한 보안 인증이 가능하며, 개발자가 더욱 편리하게 인증이 필요한 API를 테스트할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->