### PR TITLE
feat(backend): [Backend] 월간 통계 상단 요약 카드(6개) API 구현 #111

### DIFF
--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/controller/StatisticsController.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/controller/StatisticsController.java
@@ -1,0 +1,40 @@
+package com.errorterry.algotrack_backend_spring.controller;
+
+
+import com.errorterry.algotrack_backend_spring.dto.StatisticsMonthlySummaryResponseDto;
+import com.errorterry.algotrack_backend_spring.security.AuthUser;
+import com.errorterry.algotrack_backend_spring.service.StatisticsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+
+@RestController
+@RequestMapping("/api/statistics")
+@RequiredArgsConstructor
+public class StatisticsController {
+
+    private final StatisticsService statisticsService;
+
+    // 월간 요약 통계 API
+    @GetMapping("/monthly-summary")
+    public ResponseEntity<StatisticsMonthlySummaryResponseDto> getMonthlySummary(
+            @RequestParam("date")
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate baseDate
+    ) {
+
+        Integer userId = AuthUser.getUserId();
+
+        StatisticsMonthlySummaryResponseDto response =
+                statisticsService.getMonthlySummary(userId, baseDate);
+
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/dto/StatisticsMonthlySummaryResponseDto.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/dto/StatisticsMonthlySummaryResponseDto.java
@@ -1,0 +1,37 @@
+package com.errorterry.algotrack_backend_spring.dto;
+
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class StatisticsMonthlySummaryResponseDto {
+
+    // 기준일 정보 (디버깅/프론트 표시용)
+    private LocalDate baseDate;
+    private LocalDate monthStartDate;
+    private LocalDate monthEndDate;
+
+    // 1) 이번 달 총 풀이 수
+    private long totalSolved;
+
+    // 2) 주간 평균 풀이 수
+    private double weeklyAverage;
+
+    // 3) 일간 평균 풀이 수
+    private double dailyAverage;
+
+    // 4) 문제 푼 일수 / 해당 월 총 일수
+    private int solvedDays;
+    private int totalDays;
+
+    // 5) 가장 많이 푼 알고리즘
+    private String topAlgorithmName;       // 없으면 null
+    private Long topAlgorithmSolvedCount;  // 없으면 null
+
+    // 6) 가장 많이 푼 문제 티어
+    private String topProblemTier;         // 없으면 null
+    private Long topProblemTierSolvedCount;// 없으면 null
+
+}

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/repository/SolvedLogStatisticsRepository.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/repository/SolvedLogStatisticsRepository.java
@@ -1,0 +1,70 @@
+package com.errorterry.algotrack_backend_spring.repository;
+
+import com.errorterry.algotrack_backend_spring.domain.SolvedLog;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface SolvedLogStatisticsRepository extends Repository<SolvedLog, Integer> {
+
+    // 상단 요약 카드
+    // 이번 달 총 풀이 수
+    long countByUserUserIdAndSolvedDateBetween(
+            Integer userId,
+            LocalDate startDate,
+            LocalDate endDate
+    );
+
+    // 문제 푼 일수
+    @Query("""
+        SELECT COUNT(DISTINCT sl.solvedDate)
+        FROM SolvedLog sl
+        WHERE sl.user.userId = :userId AND sl.solvedDate BETWEEN :startDate AND :endDate
+    """)
+    long countSolvedDaysInMonth(
+            @Param("userId") Integer userId,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate
+    );
+
+    // 가장 많이 푼 알고리즘
+    interface AlgorithmCountProjection {
+        Integer getAlgorithmId();
+        Long getSolvedCount();
+    }
+
+    @Query("""
+        SELECT sl.algorithm.algorithmId AS algorithmId, COUNT(sl) AS solvedCount
+        FROM SolvedLog sl
+        WHERE sl.user.userId = :userId AND sl.solvedDate BETWEEN :startDate AND :endDate
+        GROUP BY sl.algorithm.algorithmId
+        ORDER BY solvedCount DESC, algorithmId ASC
+    """)
+    List<AlgorithmCountProjection> findTopAlgorithmsBySolvedCount(
+            @Param("userId") Integer userId,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate
+    );
+
+    // 가장 많이 푼 문제 티어
+    interface TierCountProjection {
+        String getProblemTier();
+        Long getSolvedCount();
+    }
+
+    @Query("""
+        SELECT sl.problemTier AS problemTier, COUNT(sl) AS solvedCount
+        FROM SolvedLog sl
+        WHERE sl.user.userId = :userId AND sl.solvedDate BETWEEN :startDate AND :endDate
+        GROUP BY sl.problemTier
+    """)
+    List<TierCountProjection> findTierStatsBySolvedCount(
+            @Param("userId") Integer userId,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate
+    );
+
+}

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/service/StatisticsService.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/service/StatisticsService.java
@@ -1,0 +1,119 @@
+package com.errorterry.algotrack_backend_spring.service;
+
+import com.errorterry.algotrack_backend_spring.domain.Algorithm;
+import com.errorterry.algotrack_backend_spring.dto.StatisticsMonthlySummaryResponseDto;
+import com.errorterry.algotrack_backend_spring.repository.AlgorithmRepository;
+import com.errorterry.algotrack_backend_spring.repository.SolvedLogStatisticsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StatisticsService {
+
+    private final SolvedLogStatisticsRepository solvedLogStatisticsRepository;
+    private final AlgorithmRepository algorithmRepository;
+
+    // problem_tier 우선순위
+    private static final List<String> TIER_ORDER = List.of(
+            "X", "Unrated", "Bronze", "Silver", "Gold", "Platinum", "Diamond", "Ruby"
+    );
+
+    // 월간 통계 요약 조회
+    public StatisticsMonthlySummaryResponseDto getMonthlySummary(Integer userId, LocalDate baseDate) {
+        YearMonth yearMonth = YearMonth.from(baseDate);
+        LocalDate monthStart = yearMonth.atDay(1);
+        LocalDate monthEnd = yearMonth.atEndOfMonth();
+        int totalDays = yearMonth.lengthOfMonth();
+
+        // 이번 달 총 풀이 수
+        long totalSolved = solvedLogStatisticsRepository.countByUserUserIdAndSolvedDateBetween(
+                userId, monthStart, monthEnd
+        );
+
+        // 문제 푼 일수
+        long solvedDays = solvedLogStatisticsRepository.countSolvedDaysInMonth(
+                userId, monthStart, monthEnd
+        );
+
+        // 주간 평균 풀이 수
+        int weekCount = (int) Math.ceil(totalDays / 7.0);
+        double weeklyAverage = weekCount > 0
+                ? (double) totalSolved / weekCount
+                : 0.0;
+
+        // 일간 평균 풀이 수
+        double dailyAverage = totalDays > 0
+                ? (double) totalSolved / totalDays
+                : 0.0;
+
+        // 가장 많이 푼 알고리즘
+        String topAlgorithmName = null;
+        Long topAlgorithmSolvedCount = null;
+
+        List<SolvedLogStatisticsRepository.AlgorithmCountProjection> algorithmStats =
+                solvedLogStatisticsRepository.findTopAlgorithmsBySolvedCount(userId, monthStart, monthEnd);
+
+        if (!algorithmStats.isEmpty()) {
+            // 쿼리에서 solvedCount desc, algorithmId asc 정렬되어 있음
+            SolvedLogStatisticsRepository.AlgorithmCountProjection top = algorithmStats.get(0);
+            Integer topAlgorithmId = top.getAlgorithmId();
+            topAlgorithmSolvedCount = top.getSolvedCount();
+
+            Optional<Algorithm> algorithmOpt = algorithmRepository.findById(topAlgorithmId);
+            topAlgorithmName = algorithmOpt.map(Algorithm::getAlgorithmName).orElse(null);
+        }
+
+        // 가장 많이 푼 문제 티어
+        String topProblemTier = null;
+        Long topProblemTierSolvedCount = null;
+
+        List<SolvedLogStatisticsRepository.TierCountProjection> tierStats =
+                solvedLogStatisticsRepository.findTierStatsBySolvedCount(userId, monthStart, monthEnd);
+
+        if (!tierStats.isEmpty()) {
+            Optional<SolvedLogStatisticsRepository.TierCountProjection> topTierOpt =
+                    tierStats.stream()
+                            .max(
+                                    Comparator
+                                            .comparingLong(SolvedLogStatisticsRepository.TierCountProjection::getSolvedCount)
+                                            .thenComparingInt(t -> tierPriority(t.getProblemTier()))
+                            );
+
+            SolvedLogStatisticsRepository.TierCountProjection topTier = topTierOpt.get();
+            topProblemTier = topTier.getProblemTier();
+            topProblemTierSolvedCount = topTier.getSolvedCount();
+        }
+
+        return StatisticsMonthlySummaryResponseDto.builder()
+                .baseDate(baseDate)
+                .monthStartDate(monthStart)
+                .monthEndDate(monthEnd)
+                .totalSolved(totalSolved)
+                .weeklyAverage(weeklyAverage)
+                .dailyAverage(dailyAverage)
+                .solvedDays((int) solvedDays)
+                .totalDays(totalDays)
+                .topAlgorithmName(topAlgorithmName)
+                .topAlgorithmSolvedCount(topAlgorithmSolvedCount)
+                .topProblemTier(topProblemTier)
+                .topProblemTierSolvedCount(topProblemTierSolvedCount)
+                .build();
+
+    }
+
+    // 티어 문자열을 내부 우선순위 값으로 반환
+    private int tierPriority(String tier) {
+        int idx = TIER_ORDER.indexOf(tier);
+        return Math.max(idx, 0); // 모르는 값이면 가장 낮은 우선순위
+    }
+
+}


### PR DESCRIPTION
## 개요
통계 화면 상단에 표시되는 **월간 요약 카드 6종에 필요한 값을 한 번에 반환하는 API** 구현
프론트에서 전달받은 기준 날짜를 기반으로 해당 월 전체 범위로 데이터를 집계하였음

## 변경 범위
- [ ] Frontend
- [x] Backend
- [ ] Infra/Docs

## 관련 이슈
- Closes #111 

## 변경 내용
- 월간 통계 상단 요약 카드(6종) 반환 API 구현
- 기준 날짜를 전달받아 해당 월 전체 범위로 통계 데이터 계산
- 통계 전용 Repository(SolvedLogStatisticsRepository) 추가 및 집계용 쿼리 분리
- 월간 요약 DTO(StatisticsMonthlySummaryResponse) 추가
- 통계 서비스(StatisticsService) 구현: 총 풀이 수, 주간/일간 평균, 문제 푼 일수, 최다 알고리즘/티어 계산 로직 포함
- 월간 통계 컨트롤러(StatisticsController) 추가

## 체크리스트
- [x] 로컬 빌드/테스트 통과 (frontend / backend)
- [ ] 브레이킹 체인지 시 문서 업데이트
- [x] 라벨/프로젝트/마일스톤 지정

## 스크린샷/로그 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 월간 통계 조회 기능 추가: 특정 날짜 기준으로 월간 문제 해결 통계를 조회할 수 있습니다. 총 해결 문제 수, 주간/일일 평균, 해결한 날짜 현황, 가장 자주 푼 알고리즘 및 난이도 정보를 확인할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->