### PR TITLE
feat(backend): [Backend] 월간 통계 기반 알고리즘 조언 기능 추가 #113

### DIFF
--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/controller/StatisticsController.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/controller/StatisticsController.java
@@ -1,7 +1,7 @@
 package com.errorterry.algotrack_backend_spring.controller;
 
 
-import com.errorterry.algotrack_backend_spring.dto.StatisticsMonthlySummaryResponseDto;
+import com.errorterry.algotrack_backend_spring.dto.MonthlyStatisticsResponseDto;
 import com.errorterry.algotrack_backend_spring.security.AuthUser;
 import com.errorterry.algotrack_backend_spring.service.StatisticsService;
 import lombok.RequiredArgsConstructor;
@@ -21,9 +21,9 @@ public class StatisticsController {
 
     private final StatisticsService statisticsService;
 
-    // 월간 요약 통계 API
+    // 월간 통계 + 조언 통합 응답 API
     @GetMapping("/monthly-summary")
-    public ResponseEntity<StatisticsMonthlySummaryResponseDto> getMonthlySummary(
+    public ResponseEntity<MonthlyStatisticsResponseDto> getMonthlySummary(
             @RequestParam("date")
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
             LocalDate baseDate
@@ -31,10 +31,11 @@ public class StatisticsController {
 
         Integer userId = AuthUser.getUserId();
 
-        StatisticsMonthlySummaryResponseDto response =
+        MonthlyStatisticsResponseDto response =
                 statisticsService.getMonthlySummary(userId, baseDate);
 
         return ResponseEntity.ok(response);
+
     }
 
 }

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/dto/MonthlyStatisticsResponseDto.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/dto/MonthlyStatisticsResponseDto.java
@@ -1,0 +1,16 @@
+package com.errorterry.algotrack_backend_spring.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MonthlyStatisticsResponseDto {
+
+    // 상단 요약 카드(6개) 정보
+    private StatisticsMonthlySummaryResponseDto summary;
+
+    // 월 통계를 기반으로 한 알고리즘/난이도 조언
+    private StatisticsMonthlyAdviceResponseDto advice;
+
+}

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/dto/StatisticsMonthlyAdviceResponseDto.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/dto/StatisticsMonthlyAdviceResponseDto.java
@@ -1,0 +1,23 @@
+package com.errorterry.algotrack_backend_spring.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class StatisticsMonthlyAdviceResponseDto {
+
+    // 알고리즘 풀이 비중 기반 조언
+    private String lowestRatioAlgorithmName;
+    private Double lowestRatioPercent;
+
+    // 알고리즘 편향 감지 조언
+    private String biasedAlgorithmName;
+    private Double biasedAlgorithmPercent;
+
+    // 난이도 상승 패턴 조언
+    private String difficultyWeeklyTrend;               // "UP", "DOWN", "SAME", "NONE"
+    private Integer difficultyWeeklyTrendStreakWeeks;   // 동일 트렌드가 몇 주 연속 유지되는지
+    private String difficultyMonthlyTrend;              // "UP", "DOWN", "SAME", "NONE"
+
+}

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/repository/SolvedLogStatisticsRepository.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/repository/SolvedLogStatisticsRepository.java
@@ -67,4 +67,11 @@ public interface SolvedLogStatisticsRepository extends Repository<SolvedLog, Int
             @Param("endDate") LocalDate endDate
     );
 
+    // 특정 범위 내 solved_log 전체 조회
+    List<SolvedLog> findByUserUserIdAndSolvedDateBetween(
+            Integer userId,
+            LocalDate startDate,
+            LocalDate endDate
+    );
+
 }

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/service/StatisticsService.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/service/StatisticsService.java
@@ -1,6 +1,9 @@
 package com.errorterry.algotrack_backend_spring.service;
 
 import com.errorterry.algotrack_backend_spring.domain.Algorithm;
+import com.errorterry.algotrack_backend_spring.domain.SolvedLog;
+import com.errorterry.algotrack_backend_spring.dto.MonthlyStatisticsResponseDto;
+import com.errorterry.algotrack_backend_spring.dto.StatisticsMonthlyAdviceResponseDto;
 import com.errorterry.algotrack_backend_spring.dto.StatisticsMonthlySummaryResponseDto;
 import com.errorterry.algotrack_backend_spring.repository.AlgorithmRepository;
 import com.errorterry.algotrack_backend_spring.repository.SolvedLogStatisticsRepository;
@@ -10,9 +13,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.YearMonth;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -22,17 +24,56 @@ public class StatisticsService {
     private final SolvedLogStatisticsRepository solvedLogStatisticsRepository;
     private final AlgorithmRepository algorithmRepository;
 
-    // problem_tier 우선순위
+    // 티어 문자열 우선순위 / 점수 매핑
     private static final List<String> TIER_ORDER = List.of(
             "X", "Unrated", "Bronze", "Silver", "Gold", "Platinum", "Diamond", "Ruby"
     );
 
-    // 월간 통계 요약 조회
-    public StatisticsMonthlySummaryResponseDto getMonthlySummary(Integer userId, LocalDate baseDate) {
+    private static final Map<String, Double> TIER_SCORE_MAP = Map.ofEntries(
+            Map.entry("X", 0.0),
+            Map.entry("Unrated", 0.0),
+            Map.entry("Bronze", 1.0),
+            Map.entry("Silver", 2.0),
+            Map.entry("Gold", 3.0),
+            Map.entry("Platinum", 4.0),
+            Map.entry("Diamond", 5.0),
+            Map.entry("Ruby", 6.0)
+    );
+
+    private static final double EPS = 0.1;                // 난이도 변화 판단 허용 오차
+    private static final double BIASED_THRESHOLD = 40.0;  // 편향 판단 비율(%)
+
+    // 티어 문자열을 내부 우선순위 값으로 반환
+    private int tierPriority(String tier) {
+        int idx = TIER_ORDER.indexOf(tier);
+        return Math.max(idx, 0); // 모르는 값이면 가장 낮은 우선순위
+    }
+
+    // 티어 문자열을 난이도 점수로 변환
+    private double tierScore(String tier) {
+        return TIER_SCORE_MAP.getOrDefault(tier, 0.0);
+    }
+
+    // 평균 티어 계산 공통 함수
+    private Double calcAverageTierScore(List<SolvedLog> logs) {
+        if (logs == null || logs.isEmpty()) {
+            return null;
+        }
+        return logs.stream()
+                .mapToDouble(log -> tierScore(log.getProblemTier()))
+                .average()
+                .orElse(0.0);
+    }
+
+
+    // MonthlyStatisticsResponseDto
+    public MonthlyStatisticsResponseDto getMonthlySummary(Integer userId, LocalDate baseDate) {
         YearMonth yearMonth = YearMonth.from(baseDate);
         LocalDate monthStart = yearMonth.atDay(1);
         LocalDate monthEnd = yearMonth.atEndOfMonth();
         int totalDays = yearMonth.lengthOfMonth();
+
+        // ===== 상단 요약 카드 통계 =====
 
         // 이번 달 총 풀이 수
         long totalSolved = solvedLogStatisticsRepository.countByUserUserIdAndSolvedDateBetween(
@@ -46,14 +87,10 @@ public class StatisticsService {
 
         // 주간 평균 풀이 수
         int weekCount = (int) Math.ceil(totalDays / 7.0);
-        double weeklyAverage = weekCount > 0
-                ? (double) totalSolved / weekCount
-                : 0.0;
+        double weeklyAverage = weekCount > 0 ? (double) totalSolved / weekCount : 0.0;
 
         // 일간 평균 풀이 수
-        double dailyAverage = totalDays > 0
-                ? (double) totalSolved / totalDays
-                : 0.0;
+        double dailyAverage = totalDays > 0 ? (double) totalSolved / totalDays : 0.0;
 
         // 가장 많이 푼 알고리즘
         String topAlgorithmName = null;
@@ -93,7 +130,7 @@ public class StatisticsService {
             topProblemTierSolvedCount = topTier.getSolvedCount();
         }
 
-        return StatisticsMonthlySummaryResponseDto.builder()
+        StatisticsMonthlySummaryResponseDto summary = StatisticsMonthlySummaryResponseDto.builder()
                 .baseDate(baseDate)
                 .monthStartDate(monthStart)
                 .monthEndDate(monthEnd)
@@ -108,12 +145,190 @@ public class StatisticsService {
                 .topProblemTierSolvedCount(topProblemTierSolvedCount)
                 .build();
 
+        // ===== 조언(Advice) 계산 =====
+        StatisticsMonthlyAdviceResponseDto advice =
+                buildAdvice(userId, yearMonth, monthStart, monthEnd, totalSolved);
+
+        // ===== summary + advice 묶어서 최종 DTO 반환 =====
+        return MonthlyStatisticsResponseDto.builder()
+                .summary(summary)
+                .advice(advice)
+                .build();
     }
 
-    // 티어 문자열을 내부 우선순위 값으로 반환
-    private int tierPriority(String tier) {
-        int idx = TIER_ORDER.indexOf(tier);
-        return Math.max(idx, 0); // 모르는 값이면 가장 낮은 우선순위
+    // 조언 전용 빌더
+    private StatisticsMonthlyAdviceResponseDto buildAdvice(
+            Integer userId,
+            YearMonth yearMonth,
+            LocalDate monthStart,
+            LocalDate monthEnd,
+            long totalSolved
+    ) {
+        // 1) 알고리즘 풀이 비중 기반 조언 + 편향 감지
+        String lowestRatioAlgorithmName = null;
+        Double lowestRatioPercent = null;
+        String biasedAlgorithmName = null;
+        Double biasedAlgorithmPercent = null;
+
+        List<SolvedLogStatisticsRepository.AlgorithmCountProjection> algorithmStats =
+                solvedLogStatisticsRepository.findTopAlgorithmsBySolvedCount(userId, monthStart, monthEnd);
+
+        if (totalSolved > 0 && !algorithmStats.isEmpty()) {
+
+            // algorithmId -> name 매핑
+            Map<Integer, String> algorithmNameMap = algorithmRepository.findAllById(
+                            algorithmStats.stream()
+                                    .map(SolvedLogStatisticsRepository.AlgorithmCountProjection::getAlgorithmId)
+                                    .collect(Collectors.toSet())
+                    ).stream()
+                    .collect(Collectors.toMap(
+                            Algorithm::getAlgorithmId,
+                            Algorithm::getAlgorithmName
+                    ));
+
+            double minRatio = Double.MAX_VALUE;
+            String minAlgoName = null;
+
+            double biasedMaxRatio = Double.MIN_VALUE;
+            String biasedAlgoNameTemp = null;
+
+            for (var stat : algorithmStats) {
+
+                long count = stat.getSolvedCount();
+                double ratio = (double) count * 100.0 / (double) totalSolved;
+
+                String name = algorithmNameMap.get(stat.getAlgorithmId());
+
+                // 가장 낮은 비중 알고리즘만 계산
+                if (ratio < minRatio) {
+                    minRatio = ratio;
+                    minAlgoName = name;
+                }
+
+                // 편향 감지 (특정 비율 이상)
+                if (ratio >= BIASED_THRESHOLD && ratio > biasedMaxRatio) {
+                    biasedMaxRatio = ratio;
+                    biasedAlgoNameTemp = name;
+                }
+            }
+
+            lowestRatioAlgorithmName = minAlgoName;
+            lowestRatioPercent = (minRatio == Double.MAX_VALUE) ? null : minRatio;
+
+            if (biasedAlgoNameTemp != null) {
+                biasedAlgorithmName = biasedAlgoNameTemp;
+                biasedAlgorithmPercent = biasedMaxRatio;
+            }
+        }
+
+        // 2) 난이도 상승 패턴 조언 (주 단위 + 월 단위)
+        String weeklyTrend = "NONE";
+        Integer weeklyTrendStreak = 0;
+        Double previousAvgTier = null;
+        Double currentAvgTier = null;
+        String monthlyTrend = "NONE";
+
+        // 이번 달 solved_log 전체 조회
+        List<SolvedLog> currentMonthLogs =
+                solvedLogStatisticsRepository.findByUserUserIdAndSolvedDateBetween(userId, monthStart, monthEnd);
+
+        // (a) 주 단위 평균 티어 계산
+        if (!currentMonthLogs.isEmpty()) {
+            Map<Integer, List<Double>> weekScoreMap = new HashMap<>();
+
+            for (SolvedLog log : currentMonthLogs) {
+                int dayOfMonth = log.getSolvedDate().getDayOfMonth();
+                int weekIndex = (dayOfMonth - 1) / 7; // 0-based
+
+                double score = tierScore(log.getProblemTier());
+
+                weekScoreMap
+                        .computeIfAbsent(weekIndex, k -> new ArrayList<>())
+                        .add(score);
+            }
+
+            List<Integer> sortedWeeks = weekScoreMap.keySet().stream().sorted().toList();
+            List<Double> weeklyAverages = new ArrayList<>();
+
+            for (Integer w : sortedWeeks) {
+                List<Double> scores = weekScoreMap.get(w);
+                double avg = scores.stream().mapToDouble(Double::doubleValue).average().orElse(0.0);
+                weeklyAverages.add(avg);
+            }
+
+            if (weeklyAverages.size() >= 2) {
+                List<String> weekTrends = new ArrayList<>();
+
+                for (int i = 1; i < weeklyAverages.size(); i++) {
+                    double prev = weeklyAverages.get(i - 1);
+                    double curr = weeklyAverages.get(i);
+                    double diff = curr - prev;
+
+                    if (diff > EPS) {
+                        weekTrends.add("UP");
+                    } else if (diff < -EPS) {
+                        weekTrends.add("DOWN");
+                    } else {
+                        weekTrends.add("SAME");
+                    }
+                }
+
+                String lastTrend = weekTrends.get(weekTrends.size() - 1);
+                weeklyTrend = lastTrend;
+
+                int streak = 1;
+                for (int i = weekTrends.size() - 2; i >= 0; i--) {
+                    if (weekTrends.get(i).equals(lastTrend)) {
+                        streak++;
+                    } else {
+                        break;
+                    }
+                }
+                weeklyTrendStreak = streak;
+            } else {
+                weeklyTrend = "NONE";
+                weeklyTrendStreak = 0;
+            }
+        } else {
+            weeklyTrend = "NONE";
+            weeklyTrendStreak = 0;
+        }
+
+        // (b) 월 단위 평균 티어 (지난달 vs 이번달)
+        currentAvgTier = calcAverageTierScore(currentMonthLogs);
+
+        YearMonth prevYearMonth = yearMonth.minusMonths(1);
+        LocalDate prevMonthStart = prevYearMonth.atDay(1);
+        LocalDate prevMonthEnd = prevYearMonth.atEndOfMonth();
+
+        List<SolvedLog> prevMonthLogs =
+                solvedLogStatisticsRepository.findByUserUserIdAndSolvedDateBetween(userId, prevMonthStart, prevMonthEnd);
+
+        previousAvgTier = calcAverageTierScore(prevMonthLogs);
+
+        if (previousAvgTier != null && currentAvgTier != null) {
+            double diff = currentAvgTier - previousAvgTier;
+            if (diff > EPS) {
+                monthlyTrend = "UP";
+            } else if (diff < -EPS) {
+                monthlyTrend = "DOWN";
+            } else {
+                monthlyTrend = "SAME";
+            }
+        } else {
+            monthlyTrend = "NONE";
+        }
+
+        return StatisticsMonthlyAdviceResponseDto.builder()
+                .lowestRatioAlgorithmName(lowestRatioAlgorithmName)
+                .lowestRatioPercent(lowestRatioPercent)
+                .biasedAlgorithmName(biasedAlgorithmName)
+                .biasedAlgorithmPercent(biasedAlgorithmPercent)
+                .difficultyWeeklyTrend(weeklyTrend)
+                .difficultyWeeklyTrendStreakWeeks(weeklyTrendStreak)
+                .difficultyMonthlyTrend(monthlyTrend)
+                .build();
     }
+
 
 }


### PR DESCRIPTION
## 개요
- 월간 통계 기반 알고리즘 조언 기능 추가

## 변경 범위
- [ ] Frontend
- [x] Backend
- [ ] Infra/Docs

## 관련 이슈
- Closes #113 

## 변경 내용
- 월간 통계 API 응답에 3가지 알고리즘 조언 데이터 추가 
### 1) 알고리즘 풀이 비중 기반 조언
- 가장 낮은 풀이 비중 알고리즘명 및 비중(% ) 계산 로직 구현 
### 2) 알고리즘 편향 감지 조언
- 특정 비중 이상 편향된 알고리즘 탐지 로직 추가
- 편향 알고리즘 이름 및 비중 반환 
### 3) 난이도 상승 패턴 조언
- 주별 평균 티어 기반 상승/하락/유지 판단
- 연속 패턴 주 수 계산
- 지난달 대비 이번달 평균 난이도 변동(UP/DOWN/SAME/NONE) 분석
###
- MonthlyStatisticsResponseDto 내부에 summary + advice 구조로 응답 포맷 통합
- StatisticsService에 조언 분석 로직 추가 및 average tier score 내부 계산으로 변경
- 기존 월간 통계 기능과 완전 호환되도록 구조 정리

## 체크리스트
- [x] 로컬 빌드/테스트 통과 (frontend / backend)
- [ ] 브레이킹 체인지 시 문서 업데이트
- [x] 라벨/프로젝트/마일스톤 지정

## 스크린샷/로그 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 월간 통계에 개인화된 조언 기능 추가
  * 알고리즘별 풀이율 분석으로 가장 취약한 알고리즘 식별
  * 편향된 알고리즘 감지 및 개선 제안
  * 주간 및 월간 난이도 추세 정보 제공

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->