### PR TITLE
feat(backend): [Backend] 월간 통계 - 요일별 평균 풀이 통계 기능 추가 #115

### DIFF
--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/dto/MonthlyStatisticsResponseDto.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/dto/MonthlyStatisticsResponseDto.java
@@ -3,6 +3,8 @@ package com.errorterry.algotrack_backend_spring.dto;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.List;
+
 @Getter
 @Builder
 public class MonthlyStatisticsResponseDto {
@@ -12,5 +14,8 @@ public class MonthlyStatisticsResponseDto {
 
     // 월 통계를 기반으로 한 알고리즘/난이도 조언
     private StatisticsMonthlyAdviceResponseDto advice;
+
+    // 요일별 평균 풀이 수 통계
+    private List<StatisticsWeekdayStatDto> weekdayStats;
 
 }

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/dto/StatisticsWeekdayStatDto.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/dto/StatisticsWeekdayStatDto.java
@@ -1,0 +1,14 @@
+package com.errorterry.algotrack_backend_spring.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class StatisticsWeekdayStatDto {
+
+    private int dayOfWeek;      // 0=일, 1=월, ..., 6=토
+    private String label;       // 표시용 한글 라벨 ("일", "월", ..., "토")
+    private Double avgSolved;   // 해당 요일의 월간 평균 풀이 수
+
+}

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/service/StatisticsService.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/service/StatisticsService.java
@@ -5,6 +5,7 @@ import com.errorterry.algotrack_backend_spring.domain.SolvedLog;
 import com.errorterry.algotrack_backend_spring.dto.MonthlyStatisticsResponseDto;
 import com.errorterry.algotrack_backend_spring.dto.StatisticsMonthlyAdviceResponseDto;
 import com.errorterry.algotrack_backend_spring.dto.StatisticsMonthlySummaryResponseDto;
+import com.errorterry.algotrack_backend_spring.dto.StatisticsWeekdayStatDto;
 import com.errorterry.algotrack_backend_spring.repository.AlgorithmRepository;
 import com.errorterry.algotrack_backend_spring.repository.SolvedLogStatisticsRepository;
 import lombok.RequiredArgsConstructor;
@@ -63,6 +64,17 @@ public class StatisticsService {
                 .mapToDouble(log -> tierScore(log.getProblemTier()))
                 .average()
                 .orElse(0.0);
+    }
+
+    // 요일 라벨
+    private static final String[] WEEKDAY_LABELS = {
+            "일", "월", "화", "수", "목", "금", "토"
+    };
+
+    // LocalData -> 0=일, 1=월, ..., 6=토 인덱스 변환
+    private int toWeekdayIndex(LocalDate date) {
+        int v = date.getDayOfWeek().getValue();
+        return v % 7;   // 1~6 -> 그대로, 7(SUN) -> 0
     }
 
 
@@ -145,14 +157,25 @@ public class StatisticsService {
                 .topProblemTierSolvedCount(topProblemTierSolvedCount)
                 .build();
 
+        // ===== 해당 월 solved_log 전체 조회 =====
+        List<SolvedLog> currentMonthLogs =
+                solvedLogStatisticsRepository.findByUserUserIdAndSolvedDateBetween(
+                        userId, monthStart, monthEnd
+                );
+
         // ===== 조언(Advice) 계산 =====
         StatisticsMonthlyAdviceResponseDto advice =
                 buildAdvice(userId, yearMonth, monthStart, monthEnd, totalSolved);
+
+        // ===== 요일별 평균 풀이 수 통계 계산 =====
+        List<StatisticsWeekdayStatDto> weekdayStats =
+                buildWeekdayStats(yearMonth, currentMonthLogs);
 
         // ===== summary + advice 묶어서 최종 DTO 반환 =====
         return MonthlyStatisticsResponseDto.builder()
                 .summary(summary)
                 .advice(advice)
+                .weekdayStats(weekdayStats)
                 .build();
     }
 
@@ -328,6 +351,56 @@ public class StatisticsService {
                 .difficultyWeeklyTrendStreakWeeks(weeklyTrendStreak)
                 .difficultyMonthlyTrend(monthlyTrend)
                 .build();
+    }
+
+    // 요일별 평균 풀이 수 통계 빌더
+    private List<StatisticsWeekdayStatDto> buildWeekdayStats(YearMonth yearMonth, List<SolvedLog> currentMonthLogs) {
+
+        int[] dayCount = new int[7];        // 해당 월에서 요일별 등장 횟수 (캘린더 기준)
+        long[] solvedCount = new long[7];   // 해당 월에서 요일별 풀이 수 합계
+
+        int lengthOfMonth = yearMonth.lengthOfMonth();
+
+        // 1) 캘린더 기준 dayCount 계산 (사용자가 풀었는지와 무관)
+        for (int day = 1; day <= lengthOfMonth; day++) {
+            LocalDate date = yearMonth.atDay(day);
+            int idx = toWeekdayIndex(date); // 0=일, 1=월, ... 6=토
+            dayCount[idx]++;
+        }
+
+        // 2) solved_log 기준 solvedCount 계산
+        if (currentMonthLogs != null) {
+            for (SolvedLog log : currentMonthLogs) {
+                int idx = toWeekdayIndex(log.getSolvedDate());
+                solvedCount[idx]++;
+            }
+        }
+
+        // 3) avgSolved 계산 + DTO 생성
+        List<StatisticsWeekdayStatDto> stats = new ArrayList<>();
+
+        // 프론트 예시와 맞추기 위해: 월(1)~토(6), 마지막에 일(0)
+        int[] order = {1, 2, 3, 4, 5, 6, 0};
+
+        for (int idx : order) {
+            int days = dayCount[idx];
+            long solves = solvedCount[idx];
+
+            double avg = 0.0;
+            if (days > 0) {
+                avg = (double) solves / (double) days;
+            }
+
+            StatisticsWeekdayStatDto dto = StatisticsWeekdayStatDto.builder()
+                    .dayOfWeek(idx)
+                    .label(WEEKDAY_LABELS[idx])
+                    .avgSolved(avg)
+                    .build();
+
+            stats.add(dto);
+        }
+
+        return stats;
     }
 
 

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/service/StatisticsService.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/service/StatisticsService.java
@@ -165,7 +165,7 @@ public class StatisticsService {
 
         // ===== 조언(Advice) 계산 =====
         StatisticsMonthlyAdviceResponseDto advice =
-                buildAdvice(userId, yearMonth, monthStart, monthEnd, totalSolved);
+                buildAdvice(userId, yearMonth, monthStart, monthEnd, totalSolved, currentMonthLogs);
 
         // ===== 요일별 평균 풀이 수 통계 계산 =====
         List<StatisticsWeekdayStatDto> weekdayStats =
@@ -185,7 +185,8 @@ public class StatisticsService {
             YearMonth yearMonth,
             LocalDate monthStart,
             LocalDate monthEnd,
-            long totalSolved
+            long totalSolved,
+            List<SolvedLog> currentMonthLogs
     ) {
         // 1) 알고리즘 풀이 비중 기반 조언 + 편향 감지
         String lowestRatioAlgorithmName = null;
@@ -250,10 +251,6 @@ public class StatisticsService {
         Double previousAvgTier = null;
         Double currentAvgTier = null;
         String monthlyTrend = "NONE";
-
-        // 이번 달 solved_log 전체 조회
-        List<SolvedLog> currentMonthLogs =
-                solvedLogStatisticsRepository.findByUserUserIdAndSolvedDateBetween(userId, monthStart, monthEnd);
 
         // (a) 주 단위 평균 티어 계산
         if (!currentMonthLogs.isEmpty()) {

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/service/StatisticsService.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/service/StatisticsService.java
@@ -71,7 +71,7 @@ public class StatisticsService {
             "일", "월", "화", "수", "목", "금", "토"
     };
 
-    // LocalData -> 0=일, 1=월, ..., 6=토 인덱스 변환
+    // LocalDate -> 0=일, 1=월, ..., 6=토 인덱스 변환
     private int toWeekdayIndex(LocalDate date) {
         int v = date.getDayOfWeek().getValue();
         return v % 7;   // 1~6 -> 그대로, 7(SUN) -> 0


### PR DESCRIPTION
## 개요
**월간 통계 API(`/api/statistics/monthly-summary`)에 요일별 평균 풀이 수(weekdayStats) 통계 추가**
solved_log 데이터를 요일별로 그룹핑하여 **각 요일에 대한 평균 풀이 수 산출**

## 변경 범위
- [ ] Frontend
- [x] Backend
- [ ] Infra/Docs

## 관련 이슈
- Closes #115 

## 변경 내용
- 월간 통계 API에 요일별 평균 풀이 수(weekdayStats) 계산 기능 추가
- 새로운 DTO `StatisticsWeekdayStatDto` 생성 
· dayOfWeek(0=일~6=토), label("월"~"일"), avgSolved(Double) 필드 구성
- StatisticsService에 요일별 통계 계산 로직 추가 
· 해당 월의 요일별 등장 횟수(dayCount) 계산 
· solved_log 기반 요일별 풀이 수(solvedCount) 집계 
· avgSolved = solvedCount / dayCount 로 산출 
· 프론트 요구에 맞게 월(1)~토(6) 뒤에 일(0) 순서로 정렬하여 반환
- MonthlyStatisticsResponseDto에 weekdayStats 필드 추가
- 기존 월간 통계(summary + advice) 구조와 완전 호환되도록 업데이트

## 체크리스트
- [x] 로컬 빌드/테스트 통과 (frontend / backend)
- [ ] 브레이킹 체인지 시 문서 업데이트
- [x] 라벨/프로젝트/마일스톤 지정

## 스크린샷/로그 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 월간 통계에 요일별 상세 분석이 추가되었습니다. 각 요일별 평균 해결 문제 수를 확인해 요일별 학습 패턴과 효율성을 더 잘 파악할 수 있습니다.
  * 통계 응답이 요일별 통계를 포함하도록 확장되어 대시보드 및 리포트에서 바로 확인할 수 있습니다.
  * 통계 기반의 맞춤형 조언에 현재 월의 요일별 데이터가 반영되어 더 정밀한 피드백을 제공합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->