### PR TITLE
feat(backend): [Backend] 월간 통계 - 목표 대비 알고리즘별 통계 기능 추가 #119

### DIFF
--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/dto/MonthlyStatisticsResponseDto.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/dto/MonthlyStatisticsResponseDto.java
@@ -21,4 +21,7 @@ public class MonthlyStatisticsResponseDto {
     // 알고리즘 군집 기반 육각형 그래프 데이터
     private List<StatisticsHexagonAxisDto> hexagon;
 
+    // 목표 대비 알고리즘별 통계
+    private List<StatisticsAlgorithmStatDto> algorithmStats;
+
 }

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/dto/StatisticsAlgorithmStatDto.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/dto/StatisticsAlgorithmStatDto.java
@@ -1,0 +1,15 @@
+package com.errorterry.algotrack_backend_spring.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class StatisticsAlgorithmStatDto {
+
+    private String algorithmName;   // 알고리즘명
+    private long goal;              // 해당 알고리즘에 대한 월간 목표 문제 수 합계
+    private long solved;            // 해당 알고리즘에 대한 월간 해결 문제 수 합계
+    private double ratio;           // 목표 대비 합계 비율 (%)
+
+}

--- a/backend/src/main/java/com/errorterry/algotrack_backend_spring/repository/DailyGoalRepository.java
+++ b/backend/src/main/java/com/errorterry/algotrack_backend_spring/repository/DailyGoalRepository.java
@@ -26,4 +26,11 @@ public interface DailyGoalRepository extends JpaRepository<DailyGoal, Integer> {
             LocalDate goalDate
     );
 
+    // 특정 유저의 월간 daily_goal 조회
+    List<DailyGoal> findByWeeklyGoalUserUserIdAndGoalDateBetween(
+            Integer userId,
+            LocalDate startDate,
+            LocalDate endDate
+    );
+
 }


### PR DESCRIPTION
## 개요
월간 통계 API에 **목표 대비 알고리즘별 통계 기능** 추가
사용자가 한 달 동안 설정한 `daily_goal` 기록을 기반으로 알고리즘별 **총 목표 문제 수, 총 해결 문제 수, 달성 비율(%)**을 계산하여 월간 통계 응답에 포함

## 변경 범위
- [ ] Frontend
- [x] Backend
- [ ] Infra/Docs

## 관련 이슈
- Closes #119 

## 변경 내용
- DailyGoal 기반 알고리즘별 목표/해결 통계 계산 로직 추가
- StatisticsAlgorithmStatDto 신규 생성
- MonthlyStatisticsResponseDto에 algorithmStats 필드 추가
- StatisticsService에 목표 대비 알고리즘별 통계 집계(buildAlgorithmStats) 구현
- DailyGoalRepository에 월간 조회 메서드(findByWeeklyGoalUserUserIdAndGoalDateBetween) 추가
- 월간 통계 API 응답에 algorithmStats 포함되도록 통합

## 체크리스트
- [x] 로컬 빌드/테스트 통과 (frontend / backend)
- [ ] 브레이킹 체인지 시 문서 업데이트
- [x] 라벨/프로젝트/마일스톤 지정

## 스크린샷/로그 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 월간 통계 조회 시 알고리즘별 상세 통계 정보가 추가되었습니다. 각 알고리즘별 목표 수, 해결한 문제 수, 해결률을 한눈에 확인할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->